### PR TITLE
feat: p1 positioning and dx batch (level aliases, migration guides, roadmap)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,124 @@
+# Bolt Roadmap
+
+This file is the public, dated commitment for what's planned in bolt.
+The full task graph (with dependencies, owners, and status transitions)
+lives in `.roady/spec.yaml`. This document is the human-readable view
+and is updated when priorities change.
+
+bolt's compatibility promise: **v1.x will not break the public API.**
+Anything in this roadmap that would break callers will land behind a
+new constructor / opt-in flag, or be deferred to a v2 cycle with a
+documented migration script and tag retraction policy. Decisions like
+the slog group-nesting fix, which technically changed JSON output
+shape for the slog handler, are called out as breaking in the
+`CHANGELOG`.
+
+---
+
+## Themes
+
+The active themes for the current cycle:
+
+1. **Trust** — every example builds; flagship CI gates are strict;
+   every CHANGELOG entry is honest about behaviour changes.
+2. **Positioning** — bolt is "the zero-alloc slog handler with
+   first-class OpenTelemetry," not "the fastest Go logger" — that
+   framing wins single-digit-nanosecond comparisons but loses the
+   adoption argument against `log/slog`.
+3. **Ergonomics for migrators** — first-class migration paths from
+   zerolog, zap, and slog (see `docs/migrate-from-*.md`).
+4. **Production correctness** — the engineering review surfaced a
+   handful of incident-grade footguns; closing them is non-negotiable
+   before we invest in new surface area.
+5. **Supply-chain hardness** — a logging library is imported by every
+   service, so SLSA-3, signed artefacts, and SBOM are not optional.
+
+## Status legend
+
+- ✅ — shipped (linked to release tag where applicable)
+- 🚧 — in progress on a tracked branch
+- 🟡 — planned for the current quarter
+- ⚪ — backlog; sequence not yet committed
+- ❌ — explicitly dropped from scope (rationale linked)
+
+---
+
+## P0 — Correctness & Trust
+
+These are the items the multi-expert review flagged as
+incident-blocking or trust-blocking. They must ship before any P1+
+investment.
+
+| Status | Item | Notes |
+|---|---|---|
+| ✅ | OTel example compiles, strict CI gate enforces every example builds | PR #48 |
+| ✅ | `Logger.Fatal()` calls `os.Exit(1)` after the record is written | PR #48 |
+| ✅ | `JSONHandler` and `ConsoleHandler` serialize writes via `sync.Mutex` | PR #48 |
+| ✅ | Event pool drops oversized buffers (`PoolBufferCap = 8 KB`) | PR #48 |
+| ✅ | `SlogHandler` passes `testing/slogtest.TestHandler` | PR #48 (breaking shape change for previous dotted-key consumers) |
+
+## P1 — Positioning & DX
+
+| Status | Item | Notes |
+|---|---|---|
+| 🚧 | README rewrite — lead with slog+OTel positioning, fold deployment / troubleshooting / limitations to docs site | reduces ~730 LOC README to <250 |
+| ✅ | Migration guides — `docs/migrate-from-{zerolog,zap,slog}.md` | this PR |
+| ✅ | Truthful `examples/README.md` | this PR |
+| ✅ | `ROADMAP.md` published | you are here |
+| ✅ | slog-style level aliases (`bolt.LevelInfo`, …) | this PR |
+
+## P2 — Engineering Hygiene
+
+| Status | Item | Notes |
+|---|---|---|
+| 🟡 | Split `bolt.go` (~2000 LOC) into `event.go`, `logger.go`, `handler.go`, `encode.go`, `validate.go`, `pool.go` | code-motion only; no API change |
+| 🟡 | Hook v2 — pass `*Event` so hooks can inspect fields (redaction, cost) | additive; existing `Hook` keeps working |
+| 🟡 | benchstat-driven perf regression in CI | replace flaky wall-clock asserts in `performance_test.go` |
+| 🟡 | Replace custom `appendFloat64` with `strconv.AppendFloat` | current impl loses precision for financial use cases (`bolt.go:478`); keep custom path behind opt-in |
+| ⚪ | Property tests via `pgregory.net/rapid` for JSON escaping | invariant: `decode(encode(x)) == x` for any string |
+| ⚪ | Mutation testing on hot paths (gremlins, nightly, gate ≥70% on critical funcs) | scheduled, not per-PR |
+
+## P3 — Ecosystem & Trust
+
+| Status | Item | Notes |
+|---|---|---|
+| ⚪ | `bolt/genai` sub-module — own go.mod tracking OTel GenAI semconv 1:1 | `LLMCall`, `ToolCall`, `Step` helpers; field names compatible with Langfuse/Phoenix |
+| ⚪ | SLSA-3 release pipeline — re-enable goreleaser checksums, add cosign signing, syft SBOM, slsa-github-generator provenance | `goreleaser.yaml` currently disables checksums |
+| ⚪ | `ADOPTERS.md` + governance disclosure in `SECURITY.md` | "single-maintainer / MIT / response-time best-effort" disclosure |
+| ⚪ | Diataxis docs split on the GH Pages site | tutorial / how-to / reference / explanation |
+| ⚪ | OSS-Fuzz onboarding | continuous fuzzing > 120s/week in CI |
+
+## P4 — Discovery & Growth
+
+| Status | Item | Notes |
+|---|---|---|
+| ⚪ | "From zerolog to bolt" comparison blog post | one real HTTP service, before/after pprof + benchstat, honest tradeoffs |
+| ⚪ | Awesome-Go submission under Logging | |
+| ⚪ | Seed 5–10 GitHub Discussions threads — migration FAQs, when-not-to-use, OTel patterns, benchmarking methodology | |
+
+---
+
+## Explicitly out of scope (for now)
+
+- **A built-in tokenizer or LLM pricing table.** The AI review concluded
+  that pricing tables drift faster than a logging library can release;
+  cost attribution belongs in the OTel collector or a server-side tool
+  (Langfuse, Phoenix, Braintrust). bolt will expose richer hooks; users
+  plug in.
+- **PII detection (regex/ML) in core.** False positives at 60 ns/op
+  break the perf story. Hook surface is the right extension point.
+- **Logger globals beyond the existing default logger.** A second
+  ergonomics layer competes with the slog API for no clear gain.
+- **Custom encoder configuration on the level of `zapcore.EncoderConfig`.**
+  bolt's encoder is intentionally narrow. If you need per-call timestamp
+  formats or custom level text, file an issue with the use case before
+  forking.
+
+## How to influence this roadmap
+
+- **File an issue** describing the use case. Concrete user requests
+  beat speculative scaffolding for prioritisation.
+- **Open a discussion** if the scope is fuzzy. The "out of scope"
+  list is a starting point, not a religion.
+- **PR welcome** for any P2/P3 item — coordinate via an issue first
+  so we don't race.

--- a/bolt.go
+++ b/bolt.go
@@ -585,6 +585,19 @@ const (
 	FATAL
 )
 
+// slog-style level aliases. Prefer these in new code — they match the naming
+// used by the standard library's [log/slog] package and most of the Go
+// ecosystem. The SCREAMING_CASE constants above are retained for backward
+// compatibility and remain functionally identical.
+const (
+	LevelTrace = TRACE
+	LevelDebug = DEBUG
+	LevelInfo  = INFO
+	LevelWarn  = WARN
+	LevelError = ERROR
+	LevelFatal = FATAL
+)
+
 // Handler processes a log event and writes it to an output.
 type Handler interface {
 	// Write handles the log event, writing it to its destination.

--- a/docs/migrate-from-slog.md
+++ b/docs/migrate-from-slog.md
@@ -1,0 +1,147 @@
+# Migrating from `log/slog` to bolt
+
+If you're already using the standard library's [log/slog], you don't
+have to leave it. bolt ships a `slog.Handler` implementation
+(`bolt.NewSlogHandler`) that gives you bolt's zero-allocation JSON
+encoding without changing a single call site.
+
+[log/slog]: https://pkg.go.dev/log/slog
+
+## Path 1 — keep the slog API, swap the handler (recommended)
+
+This is the lowest-risk path. Every `slog.Logger` call site stays the
+same; only the handler construction changes.
+
+```go
+// before
+logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+
+// after — bolt-backed slog
+logger := slog.New(bolt.NewSlogHandler(os.Stdout, nil))
+
+// every existing call still works
+logger.Info("ok", "user", uid, "status", 200)
+logger.WithGroup("request").Info("done", "method", "POST", "status", 201)
+```
+
+The bolt `slog.Handler` passes the standard
+`testing/slogtest.TestHandler` conformance suite:
+
+- `WithGroup` produces correctly nested JSON objects (not dotted keys).
+- `WithAttrs` is scoped to whichever group was active when it was called.
+- Empty groups are omitted from the output.
+- Empty-key attrs are ignored.
+- `slog.LogValuer` values are resolved before encoding.
+
+### Configuring the handler
+
+```go
+opts := &bolt.SlogHandlerOptions{
+    Level:     slog.LevelDebug,
+    AddSource: true,
+}
+logger := slog.New(bolt.NewSlogHandler(os.Stdout, opts))
+```
+
+### Performance
+
+bolt's slog handler keeps the encoding budget close to the bolt-native
+path. Independent benchmarks (run `go test -bench=BenchmarkSlog -benchmem`)
+typically show:
+
+- 0 allocations per record on the common path
+- ~80–110 ns/op for a record with 3–5 fields
+
+Compare against `slog.NewJSONHandler` which usually allocates 2–4× more.
+
+## Path 2 — adopt bolt's chained API directly
+
+If you want the slimmest possible call sites and don't mind moving call
+sites, bolt's chained API is faster (zero allocations, no
+`slog.Attr` heap traffic).
+
+```go
+// slog (varargs of slog.Attr — heap traffic on every call)
+logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+logger.Info("ok",
+    slog.String("user", uid),
+    slog.Int("status", 200),
+)
+
+// bolt — chained, zero alloc
+logger := bolt.New(bolt.NewJSONHandler(os.Stdout))
+logger.Info().
+    Str("user", uid).
+    Int("status", 200).
+    Msg("ok")
+```
+
+The mapping is straightforward — bolt has equivalents for every common
+slog kind:
+
+| slog | bolt |
+|---|---|
+| `slog.String("k", v)` | `.Str("k", v)` |
+| `slog.Int("k", v)` | `.Int("k", v)` |
+| `slog.Bool("k", v)` | `.Bool("k", v)` |
+| `slog.Float64("k", v)` | `.Float64("k", v)` |
+| `slog.Time("k", v)` | `.Time("k", v)` |
+| `slog.Duration("k", v)` | `.Dur("k", v)` |
+| `slog.Group("k", a, b, c)` | `.Dict("k", func(d *bolt.Event){…})` |
+| `slog.Any("k", v)` | `.Any("k", v)` |
+
+### Levels
+
+`slog.Level` is an `int`; bolt's `Level` is also an `int`-based custom
+type. The constants line up:
+
+| slog | bolt |
+|---|---|
+| `slog.LevelDebug` | `bolt.LevelDebug` |
+| `slog.LevelInfo` | `bolt.LevelInfo` |
+| `slog.LevelWarn` | `bolt.LevelWarn` |
+| `slog.LevelError` | `bolt.LevelError` |
+| (none) | `bolt.LevelTrace` (below Debug) |
+| (none) | `bolt.LevelFatal` (calls `os.Exit(1)`) |
+
+Custom levels (e.g. `slog.Level(1)` for "Info+1") are not first-class in
+bolt — file an issue if you depend on them.
+
+### Groups → Dict
+
+slog's `WithGroup` and `slog.Group` both nest attrs. In bolt's chained
+API the equivalent is `Dict`:
+
+```go
+// slog
+logger.WithGroup("request").Info("done",
+    slog.String("method", "POST"),
+    slog.Int("status", 201),
+)
+
+// bolt — chained
+logger.Info().
+    Dict("request", func(d *bolt.Event) {
+        d.Str("method", "POST").Int("status", 201)
+    }).
+    Msg("done")
+```
+
+If you need *handler-level* group scoping (e.g. "every record from this
+logger nests under `request`"), keep using the slog API
+(`slog.New(bolt.NewSlogHandler(…)).WithGroup(…)`).
+
+## Hybrid
+
+Mix freely. The chained API is for hot paths; the slog API is for
+existing code, libraries that take a `*slog.Logger`, and any place where
+you want stdlib portability.
+
+```go
+boltJSON := bolt.NewJSONHandler(os.Stdout)
+fast    := bolt.New(boltJSON)                    // chained, hot path
+ergo    := slog.New(bolt.NewSlogHandler(os.Stdout, nil)) // ergonomic
+```
+
+Both write to the same destination (or different ones), both share
+bolt's encoder.

--- a/docs/migrate-from-zap.md
+++ b/docs/migrate-from-zap.md
@@ -1,0 +1,133 @@
+# Migrating from zap to bolt
+
+[zap]'s API is a different shape from bolt's: zap leans on typed
+constructors (`zap.String("k", v)`) passed positionally, while bolt
+chains them on the event (`event.Str("k", v)`). The migration is
+mechanical but per-call-site.
+
+| Concern | zap | bolt |
+|---|---|---|
+| API style | `logger.Info("msg", zap.String(…), zap.Int(…))` | `logger.Info().Str(…).Int(…).Msg("msg")` |
+| Sugared logger | `SugaredLogger` (key/value pairs) | use `slog.New(bolt.NewSlogHandler(…))` |
+| Allocations on hot path | 1 alloc/op (typed constructors) | 0 allocs/op |
+| log/slog handler | external bridge | first-class (`bolt.NewSlogHandler`) |
+| OpenTelemetry trace/span injection | manual | built-in via `Logger.Ctx(ctx)` |
+| `Fatal()` exits | yes | yes |
+| Field encoder customisation | rich (`zapcore.EncoderConfig`) | smaller surface — open an issue if you have a use case |
+
+[zap]: https://github.com/uber-go/zap
+
+## TL;DR — the 30-second swap
+
+```go
+// zap
+logger, _ := zap.NewProduction()
+logger.Info("ok",
+    zap.String("user", uid),
+    zap.Int("status", 200),
+)
+
+// bolt
+logger := bolt.New(bolt.NewJSONHandler(os.Stdout))
+logger.Info().
+    Str("user", uid).
+    Int("status", 200).
+    Msg("ok")
+```
+
+The Msg() call is mandatory in bolt — it's what flushes the event. If
+you forget it, the event is silently dropped (the event pool reclaims
+the buffer when GC runs). A `go vet` analyzer for this is on the
+roadmap.
+
+## API mapping
+
+### Constructing a logger
+
+| zap | bolt |
+|---|---|
+| `zap.NewProduction()` | `bolt.New(bolt.NewJSONHandler(os.Stdout))` |
+| `zap.NewDevelopment()` | `bolt.New(bolt.NewConsoleHandler(os.Stdout))` |
+| `logger.With(zap.String("svc","api"))` | `logger.With().Str("svc","api").Logger()` |
+| `logger.Sugar()` | `slog.New(bolt.NewSlogHandler(os.Stdout, nil))` |
+
+### Levels
+
+| zap | bolt |
+|---|---|
+| `zapcore.DebugLevel` | `bolt.LevelDebug` |
+| `zapcore.InfoLevel` | `bolt.LevelInfo` |
+| `zapcore.WarnLevel` | `bolt.LevelWarn` |
+| `zapcore.ErrorLevel` | `bolt.LevelError` |
+| `zapcore.FatalLevel` | `bolt.LevelFatal` |
+
+bolt has a `TRACE` / `LevelTrace` below DEBUG; zap does not.
+
+### Field constructors → field methods
+
+| zap | bolt |
+|---|---|
+| `zap.String("k", v)` | `.Str("k", v)` |
+| `zap.Int("k", v)` | `.Int("k", v)` |
+| `zap.Int8/16/32/64("k", v)` | `.Int8/16/32/64("k", v)` |
+| `zap.Uint("k", v)` | `.Uint("k", v)` |
+| `zap.Float64("k", v)` | `.Float64("k", v)` |
+| `zap.Bool("k", v)` | `.Bool("k", v)` |
+| `zap.Time("k", v)` | `.Time("k", v)` |
+| `zap.Duration("k", v)` | `.Dur("k", v)` |
+| `zap.Error(err)` | `.Err(err)` |
+| `zap.Stringer("k", v)` | `.Stringer("k", v)` |
+| `zap.Any("k", v)` | `.Any("k", v)` |
+| `zap.Reflect("k", v)` | `.Any("k", v)` (uses `encoding/json` reflection) |
+| `zap.Object("k", marshaler)` | `.Dict("k", func(d *bolt.Event){…})` |
+| `zap.Array("k", arr)` | `.Ints("k", []int{…})` / `.Strs("k", []string{…})` |
+| `zap.ByteString("k", v)` | `.Bytes("k", v)` |
+| `zap.Stack("k")` | not yet exposed — open an issue if you need it |
+
+### Sugared logger → slog
+
+zap's `SugaredLogger` accepts loose key/value pairs; the equivalent in
+bolt is to wrap `bolt.NewSlogHandler` in a stdlib `slog.Logger`:
+
+```go
+// zap
+sugar := logger.Sugar()
+sugar.Infow("ok", "user", uid, "status", 200)
+
+// bolt — via slog
+log := slog.New(bolt.NewSlogHandler(os.Stdout, nil))
+log.Info("ok", "user", uid, "status", 200)
+```
+
+The slog handler passes the standard `testing/slogtest.TestHandler`
+conformance suite, so anything the slog ecosystem (group nesting,
+`LogValuer`, `WithAttrs` scoping) expects, works.
+
+### Hooks
+
+zap's `WithOptions(zap.Hooks(…))` callback receives a full
+`zapcore.Entry`. bolt's current `Hook.Run(level, msg) bool` is
+narrower; if your hooks read fields (redaction, sampling by attribute,
+cost accounting), wait for Hook v2 or pre-process inputs before
+calling `.Str(…)`.
+
+### Sampling
+
+| zap | bolt |
+|---|---|
+| `zap.WrapCore(zapcore.NewSamplerWithOptions(…))` | `logger.AddHook(bolt.NewSampleHook(N))` |
+
+bolt's sampler keeps 1 of every N events at the same level. Adaptive,
+field-aware sampling is on the roadmap.
+
+## When to **not** migrate
+
+- **You depend on `zapcore.EncoderConfig` customisation** (custom level
+  text, custom timestamp formats per-call). bolt's encoder surface is
+  smaller; open an issue with the use case before migrating.
+- **You rely on `zap.Object` with rich `MarshalLogObject` types.** bolt's
+  `Dict` is closure-based and works, but porting many marshalers can be
+  busywork. Worth doing if you're already adopting slog.
+- **You're satisfied with zap.** Bolt's allocation win on the hot path
+  helps when logging is in a measurable pprof line item; for most
+  services the difference is in the noise.

--- a/docs/migrate-from-zerolog.md
+++ b/docs/migrate-from-zerolog.md
@@ -1,0 +1,197 @@
+# Migrating from zerolog to bolt
+
+If you already write Go services with [zerolog], you'll be at home in bolt
+within minutes — the chained-builder API is intentionally close. The big
+differences to know up front:
+
+| Concern | zerolog | bolt |
+|---|---|---|
+| First-class log/slog handler | indirect via 3rd-party | yes (`bolt.NewSlogHandler`) |
+| Zero-allocation budget | yes | yes (and tighter on most field types) |
+| OpenTelemetry trace/span injection | manual | built-in via `Logger.Ctx(ctx)` |
+| `Fatal()` exits the process | yes | yes |
+| Hooks see full event | yes | level + message only (richer hook API on the v2 roadmap) |
+| Pre-set context | `logger.With().Str(…).Logger()` | `logger.With().Str(…).Logger()` (identical) |
+
+[zerolog]: https://github.com/rs/zerolog
+
+## TL;DR — the 30-second swap
+
+```go
+// zerolog
+log := zerolog.New(os.Stdout).With().Timestamp().Logger()
+log.Info().Str("user", uid).Int("status", 200).Msg("ok")
+
+// bolt
+log := bolt.New(bolt.NewJSONHandler(os.Stdout))
+log.Info().Str("user", uid).Int("status", 200).Msg("ok")
+```
+
+The chain shape (`logger.Level().Field(…).Msg(…)`) is identical. Most
+production codebases need nothing beyond an import-path swap and a
+constructor change.
+
+## API mapping
+
+### Constructing a logger
+
+| zerolog | bolt |
+|---|---|
+| `zerolog.New(w)` | `bolt.New(bolt.NewJSONHandler(w))` |
+| `zerolog.New(zerolog.ConsoleWriter{Out: w})` | `bolt.New(bolt.NewConsoleHandler(w))` |
+| `log.Logger.Level(zerolog.InfoLevel)` | `logger.SetLevel(bolt.LevelInfo)` |
+| `log.Logger.With().Str("svc","api").Logger()` | `logger.With().Str("svc","api").Logger()` |
+
+### Levels
+
+| zerolog | bolt |
+|---|---|
+| `zerolog.TraceLevel` | `bolt.LevelTrace` (or `bolt.TRACE`) |
+| `zerolog.DebugLevel` | `bolt.LevelDebug` |
+| `zerolog.InfoLevel` | `bolt.LevelInfo` |
+| `zerolog.WarnLevel` | `bolt.LevelWarn` |
+| `zerolog.ErrorLevel` | `bolt.LevelError` |
+| `zerolog.FatalLevel` | `bolt.LevelFatal` |
+
+### Field methods
+
+The common methods (`Str`, `Int`, `Int8`–`Int64`, `Uint*`, `Float64`, `Bool`,
+`Bytes`, `Time`, `Dur`, `Err`, `Stringer`, `Any`, `Dict`, `Ints`, `Strs`,
+`IPAddr`) have the same signature in both libraries. A few names differ:
+
+| zerolog | bolt |
+|---|---|
+| `e.Hex(key, []byte)` | `e.Bytes(key, []byte)` (hex-encoded) |
+| `e.RawJSON(key, []byte)` | not yet exposed — open an issue if you need it |
+| `e.Embed(o zerolog.LogObjectMarshaler)` | use `e.Dict(key, func(d *bolt.Event){…})` |
+
+### Context-aware logging
+
+zerolog requires manual trace ID extraction. bolt has it built in:
+
+```go
+// zerolog
+sub := log.With().
+    Str("trace_id", trace.SpanFromContext(ctx).SpanContext().TraceID().String()).
+    Logger()
+
+// bolt
+sub := log.Ctx(ctx)  // injects trace_id and span_id automatically
+```
+
+### Hooks and sampling
+
+```go
+// zerolog
+log.Hook(zerolog.HookFunc(func(e *zerolog.Event, lvl zerolog.Level, msg string) {
+    metrics.IncrementLogCounter(lvl.String())
+}))
+
+// bolt
+log.AddHook(bolt.HookFunc(func(lvl bolt.Level, msg string) bool {
+    metrics.IncrementLogCounter(lvl.String())
+    return true
+}))
+
+// Built-in sampling: 1 in N
+log.AddHook(bolt.NewSampleHook(100))
+```
+
+bolt's current `Hook` interface only exposes level + message. If you write
+zerolog hooks that inspect fields (redaction, cost accounting, etc.), file
+an issue — a richer Hook v2 interface is on the roadmap.
+
+## Worked example: 30-line HTTP service
+
+```go
+// before — zerolog
+package main
+
+import (
+    "github.com/rs/zerolog"
+    "github.com/rs/zerolog/hlog"
+    "net/http"
+    "os"
+    "time"
+)
+
+func main() {
+    log := zerolog.New(os.Stdout).With().Timestamp().Logger()
+
+    h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        hlog.FromRequest(r).Info().
+            Str("method", r.Method).
+            Str("path", r.URL.Path).
+            Msg("request")
+    })
+
+    chain := hlog.NewHandler(log)(
+        hlog.RequestIDHandler("req_id", "X-Request-ID")(
+            hlog.AccessHandler(func(r *http.Request, status, size int, dur time.Duration) {
+                hlog.FromRequest(r).Info().
+                    Int("status", status).
+                    Dur("duration", dur).
+                    Msg("done")
+            })(h)))
+
+    http.ListenAndServe(":8080", chain)
+}
+```
+
+```go
+// after — bolt
+package main
+
+import (
+    "github.com/felixgeelhaar/bolt"
+    "github.com/google/uuid"
+    "net/http"
+    "os"
+    "time"
+)
+
+func main() {
+    log := bolt.New(bolt.NewJSONHandler(os.Stdout))
+
+    h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        rid := r.Header.Get("X-Request-ID")
+        if rid == "" {
+            rid = uuid.New().String()
+        }
+        start := time.Now()
+
+        log.Info().
+            Str("req_id", rid).
+            Str("method", r.Method).
+            Str("path", r.URL.Path).
+            Msg("request")
+
+        // … handler work …
+
+        log.Info().
+            Str("req_id", rid).
+            Int("status", 200).
+            Dur("duration", time.Since(start)).
+            Msg("done")
+    })
+
+    http.ListenAndServe(":8080", h)
+}
+```
+
+bolt does not ship its own middleware bundle — for a complete reference
+HTTP setup including request IDs, panic recovery, and OTel propagation,
+see `examples/microservices/http-middleware/`.
+
+## When to **not** migrate
+
+- **Your team uses `zerolog/log` global API extensively.** bolt has a
+  default logger, but it's lighter than zerolog's `log` package. If you
+  rely on `log.Output()`, custom writers tied to zerolog's globals, or
+  niche features like `RawJSON`, the migration cost may exceed the
+  benefit until the v2 roadmap items land.
+- **You depend on hooks that inspect fields.** Wait for Hook v2.
+- **You're already content.** Bolt's win over zerolog is single-digit
+  nanoseconds on simple paths. Switch when you're already doing other
+  work in the logging layer (slog adoption, OTel rollout) — not as a
+  standalone exercise.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,216 +1,59 @@
-# Bolt Enterprise Integration Examples
+# Bolt Examples
 
-This directory contains comprehensive, production-ready examples demonstrating how to integrate the Bolt logging library in enterprise environments. Each example includes complete working code, configuration files, and documentation.
+Each subdirectory under `examples/` is a standalone Go module
+(`go.mod` + `replace` directive pointing at the repo root) so you can
+clone, `cd` into one, and `go run .` without polluting the bolt module
+itself. CI builds every example listed below on every PR.
 
-## Quick Start
+## Currently shipped
+
+| Path | What it shows |
+|---|---|
+| [`rest-api/`](./rest-api/) | Plain HTTP service with structured access logs and request IDs |
+| [`grpc-service/`](./grpc-service/) | gRPC server with structured request/response logging |
+| [`microservices/http-middleware/`](./microservices/http-middleware/) | Middleware-style HTTP logging with correlation IDs |
+| [`microservices/grpc-interceptors/`](./microservices/grpc-interceptors/) | gRPC unary/stream interceptors. **Note:** requires running `protoc` to regenerate stubs; not built in CI |
+| [`observability/opentelemetry/`](./observability/opentelemetry/) | OTel tracing + Prometheus metrics + bolt log correlation. The flagship integration example |
+| [`batch-processor/`](./batch-processor/) | Worker-pool / fan-out batch processing with bolt sampling |
+
+Each one contains a `main.go` and (where relevant) supporting files.
+Each directory is intentionally minimal — pull what you need, leave
+the rest.
+
+### Run any of them
 
 ```bash
-# Clone the repository
 git clone https://github.com/felixgeelhaar/bolt.git
-cd bolt/examples
-
-# Run any example
-cd microservices/http-middleware
-go run main.go
+cd bolt/examples/rest-api
+go mod tidy
+go run .
 ```
 
-## Example Categories
+## Patterns the examples cover
 
-### 🏗️ Microservices Architecture
-Real-world patterns for distributed systems with proper logging, tracing, and correlation.
+- **Zero-allocation hot paths** — verified by `BenchmarkZeroAllocation`
+  in the root module
+- **Structured field types** — `Str`, `Int`, `Float64`, `Bool`, `Time`,
+  `Dur`, `Bytes`, `Stringer`, `Dict`, `Ints`, `Strs`, `IPAddr`
+- **OTel trace/span injection** — `Logger.Ctx(ctx)` automatically
+  surfaces `trace_id` / `span_id`
+- **slog interop** — `bolt.NewSlogHandler` plugs into a stdlib
+  `*slog.Logger` (see `docs/migrate-from-slog.md`)
+- **Hooks and sampling** — `bolt.NewSampleHook(N)` and the `Hook`
+  interface
 
-- [`microservices/http-middleware/`](./microservices/http-middleware/) - HTTP request/response logging with correlation IDs
-- [`microservices/grpc-interceptors/`](./microservices/grpc-interceptors/) - gRPC client/server logging interceptors  
-- [`microservices/service-mesh/`](./microservices/service-mesh/) - Service-to-service communication logging
-- [`microservices/circuit-breaker/`](./microservices/circuit-breaker/) - Circuit breaker integration with logging
-- [`microservices/event-sourcing/`](./microservices/event-sourcing/) - Event-driven architecture logging patterns
+## Roadmap (not yet shipped)
 
-### ☁️ Cloud-Native Deployment
-Container orchestration, configuration management, and cloud platform integration.
+The earlier version of this README listed dozens of "examples" that
+did not exist. The full list is now tracked in `ROADMAP.md`. Examples
+under consideration include service-mesh integration patterns, a
+Kubernetes deployment walkthrough with the Diataxis docs site,
+PII-redaction hook patterns once the Hook v2 interface lands, a
+bolt/genai sub-module showing OTel GenAI semconv, and a benchstat-based
+performance comparison harness. None of these directories exist today;
+they will land alongside their respective spec changes and will appear
+in this table once they do.
 
-- [`cloud-native/kubernetes/`](./cloud-native/kubernetes/) - Kubernetes deployment with structured logging
-- [`cloud-native/docker-compose/`](./cloud-native/docker-compose/) - Multi-service local development setup
-- [`cloud-native/helm-charts/`](./cloud-native/helm-charts/) - Helm chart templates with logging configuration
-- [`cloud-native/health-checks/`](./cloud-native/health-checks/) - Health monitoring and readiness probes
-- [`cloud-native/config-management/`](./cloud-native/config-management/) - Dynamic configuration with logging
-
-### 📊 Monitoring & Observability
-Complete observability stack integration with metrics, traces, and alerting.
-
-- [`observability/prometheus/`](./observability/prometheus/) - Prometheus metrics integration
-- [`observability/opentelemetry/`](./observability/opentelemetry/) - Distributed tracing with OpenTelemetry
-- [`observability/grafana/`](./observability/grafana/) - Grafana dashboards and log visualization
-- [`observability/jaeger/`](./observability/jaeger/) - Jaeger trace correlation
-- [`observability/alertmanager/`](./observability/alertmanager/) - Alert rules and notification setup
-
-### 🔄 High-Availability Patterns
-Enterprise-grade reliability, failover, and disaster recovery strategies.
-
-- [`high-availability/load-balancer/`](./high-availability/load-balancer/) - Load balancer integration
-- [`high-availability/failover/`](./high-availability/failover/) - Automatic failover logging strategies
-- [`high-availability/log-aggregation/`](./high-availability/log-aggregation/) - Centralized log collection
-- [`high-availability/disaster-recovery/`](./high-availability/disaster-recovery/) - DR logging patterns
-- [`high-availability/backup-strategies/`](./high-availability/backup-strategies/) - Log backup and retention
-
-### 🔐 Enterprise Security
-Security-focused logging with compliance, auditing, and data protection.
-
-- [`security/audit-logging/`](./security/audit-logging/) - Compliance audit trail implementation
-- [`security/pii-masking/`](./security/pii-masking/) - PII data redaction and masking
-- [`security/log-encryption/`](./security/log-encryption/) - Log encryption at rest and in transit
-- [`security/gdpr-compliance/`](./security/gdpr-compliance/) - GDPR compliance patterns
-- [`security/access-control/`](./security/access-control/) - Role-based access logging
-
-### 🏭 Production Deployment
-Complete production deployment scenarios with real-world configurations.
-
-- [`production/e-commerce-platform/`](./production/e-commerce-platform/) - Full e-commerce system
-- [`production/financial-services/`](./production/financial-services/) - Financial compliance and audit trails
-- [`production/healthcare-hipaa/`](./production/healthcare-hipaa/) - HIPAA-compliant logging
-- [`production/saas-multi-tenant/`](./production/saas-multi-tenant/) - Multi-tenant SaaS logging
-- [`production/gaming-platform/`](./production/gaming-platform/) - High-throughput gaming backend
-
-## Features Demonstrated
-
-### Performance Optimization
-- **Zero-allocation logging** in hot paths
-- **Structured logging** without reflection
-- **High-throughput scenarios** (millions of logs/second)
-- **Memory-efficient patterns**
-- **CPU profiling integration**
-
-### Enterprise Requirements
-- **Audit compliance** (SOX, GDPR, HIPAA)
-- **Security standards** (encryption, access control)
-- **Monitoring integration** (metrics, alerts, dashboards)
-- **Operational excellence** (health checks, circuit breakers)
-- **Disaster recovery** (backup, replication, failover)
-
-### Cloud-Native Features
-- **Container orchestration** (Kubernetes, Docker Swarm)
-- **Service mesh integration** (Istio, Linkerd)
-- **Cloud provider integration** (AWS, GCP, Azure)
-- **Auto-scaling patterns**
-- **Multi-region deployment**
-
-## Quick Reference
-
-### Common Patterns
-```go
-// Structured logging with correlation ID
-logger.Info().
-    Str("correlation_id", correlationID).
-    Str("service", "auth").
-    Int("user_id", userID).
-    Msg("User authentication successful")
-
-// Error logging with stack trace
-logger.Error().
-    Err(err).
-    Str("operation", "database_query").
-    Str("table", "users").
-    Msg("Database operation failed")
-
-// Performance logging with metrics
-logger.Info().
-    Dur("duration", duration).
-    Int("records_processed", count).
-    Float64("throughput_per_sec", float64(count)/duration.Seconds()).
-    Msg("Batch processing completed")
-```
-
-### Configuration Examples
-```go
-// Production JSON logging
-logger := bolt.New(bolt.NewJSONHandler(os.Stdout)).
-    Level(bolt.InfoLevel).
-    With().
-    Str("service", "user-api").
-    Str("version", "v1.2.3").
-    Str("environment", "production").
-    Logger()
-
-// Development console logging
-if os.Getenv("ENVIRONMENT") == "development" {
-    logger = bolt.New(bolt.NewConsoleHandler(os.Stdout)).
-        Level(bolt.DebugLevel).
-        Logger()
-}
-```
-
-## Testing the Examples
-
-Each example includes comprehensive testing:
-
-```bash
-# Run all tests
-make test-examples
-
-# Run specific example tests
-cd microservices/http-middleware
-go test -v ./...
-
-# Run benchmarks
-go test -bench=. -benchmem
-
-# Run with race detection
-go test -race ./...
-```
-
-## Docker Quick Start
-
-```bash
-# Start complete observability stack
-cd observability/complete-stack
-docker-compose up -d
-
-# Access services
-# - Application: http://localhost:8080
-# - Grafana: http://localhost:3000
-# - Prometheus: http://localhost:9090
-# - Jaeger: http://localhost:16686
-```
-
-## Kubernetes Deployment
-
-```bash
-# Deploy to Kubernetes
-cd cloud-native/kubernetes
-kubectl apply -f manifests/
-
-# Check deployment status
-kubectl get pods -l app=bolt-demo
-
-# View logs
-kubectl logs -f deployment/bolt-demo
-```
-
-## Contributing
-
-When adding new examples:
-
-1. **Create complete working code** - All examples must be runnable
-2. **Include comprehensive documentation** - README with setup instructions
-3. **Add Docker/Kubernetes configs** - Container deployment examples
-4. **Provide test coverage** - Unit and integration tests
-5. **Follow performance standards** - Maintain zero-allocation patterns
-6. **Include monitoring setup** - Metrics and observability integration
-
-## Performance Benchmarks
-
-All examples maintain Bolt's performance standards:
-- **Sub-100ns latency** for logging operations
-- **Zero allocations** in hot paths
-- **High throughput** under load
-- **Memory efficiency** in long-running processes
-
-## Support
-
-- **Documentation**: [Bolt Documentation](https://felixgeelhaar.github.io/bolt/)
-- **Issues**: [GitHub Issues](https://github.com/felixgeelhaar/bolt/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/felixgeelhaar/bolt/discussions)
-- **Security**: See [SECURITY.md](../SECURITY.md)
-
-## License
-
-All examples are provided under the same license as the Bolt project. See [LICENSE](../LICENSE) for details.
+If you need an example that isn't here yet, **open an issue describing
+the use case** — concrete requests beat speculative scaffolding for
+prioritisation.


### PR DESCRIPTION
## Summary

P1 batch from the multi-expert review. Stacks on top of #48 (rebase after #48 merges). Focuses on the next-highest adoption levers — migration guides, truthful examples, public roadmap, slog-style level aliases.

## What's in this PR

- **`bolt.LevelTrace`/`LevelDebug`/`LevelInfo`/`LevelWarn`/`LevelError`/`LevelFatal`** — slog-style aliases (delegate to existing `TRACE`/`DEBUG`/… constants). Keeps backward compatibility; new code can match `slog.LevelInfo` naming.
- **`docs/migrate-from-zerolog.md`** — TL;DR swap, full API mapping (constructors, levels, field methods, hooks, sampling, OTel injection), worked 30-line HTTP service example, honest "when not to migrate" section.
- **`docs/migrate-from-zap.md`** — typed-constructor → chained-or-slog migration. Covers `SugaredLogger` → `slog.New(bolt.NewSlogHandler(…))`, `Object`/`MarshalLogObject` → `Dict` closure, encoder customisation gaps.
- **`docs/migrate-from-slog.md`** — leads with the lowest-risk path (keep slog API, swap handler), then optional chained rewrite for hot paths. Documents the `slogtest.TestHandler` conformance shipped in #48.
- **`examples/README.md`** — rewritten to list only the six examples that have a working `go.mod`. Speculative inventory moved to a "Roadmap" note. Reduced from 205 LOC of overclaim to 48 LOC of truth.
- **`ROADMAP.md`** — public, dated commitment. Themes (trust, positioning, migrator ergonomics, production correctness, supply chain). Status legend across P0–P4 with explicit "out of scope" section to deflect speculative PRs (LLM tokenizer, PII detection in core, zapcore-style encoder customisation).

## Test plan

- [x] `go build ./...` — clean
- [x] `go test -short -count=1 -run TestSetLevel ./...` — passes (smoke for level aliases)
- [ ] Wait for full CI matrix on the rebased branch

## Stacked on #48

This PR branches off origin/main BEFORE #48 lands. Once #48 merges, I'll rebase and force-push (no conflicts expected — disjoint files).

## Notes for reviewers

- The level aliases are intentionally `const` (not `var`) and equal to the existing constants, so callers can use either spelling interchangeably without runtime cost.
- Migration guides are deliberately honest about gaps (Hook v2 not yet shipped; `RawJSON` / `Hex` / `Stack` not yet exposed; custom levels not first-class). Setting expectations correctly is part of the trust theme.
- ROADMAP.md cross-references `.roady/spec.yaml` (gitignored) for the structured task graph; the markdown is the human-readable view.