### PR TITLE
fix: float64 precision — strconv.AppendFloat for ieee-754 round-trip

### DIFF
--- a/bolt.go
+++ b/bolt.go
@@ -108,9 +108,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net"
 	"os"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -442,114 +444,29 @@ func appendNanoDigits(buf []byte, nano int) []byte {
 }
 
 // appendFloat64 appends a float64 to the buffer without allocations.
-// This implementation uses a fixed-point approach for common float values,
-// providing reasonable precision while maintaining zero allocations.
+//
+// Encoding rules:
+//   - NaN, +Inf, -Inf are emitted as JSON strings ("NaN"/"+Inf"/"-Inf")
+//     because RFC 8259 has no representation for them.
+//   - All other values are encoded via strconv.AppendFloat with the
+//     shortest-round-trip ('g', -1) verb, matching encoding/json. This
+//     preserves the full IEEE-754 precision of the input — there is no
+//     6-decimal truncation. Callers that previously logged values like
+//     transaction amounts or scientific measurements will now see the
+//     correct digits in their JSON output.
+//
+// strconv.AppendFloat writes into a small stack buffer before copying
+// into buf, so this remains 0 allocs/op on the hot path.
 func appendFloat64(buf []byte, f float64) []byte {
-	// Handle special cases
-	if f != f { // NaN
+	switch {
+	case math.IsNaN(f):
 		return append(buf, `"NaN"`...)
-	}
-	if f > 1e308 { // +Inf
+	case math.IsInf(f, 1):
 		return append(buf, `"+Inf"`...)
-	}
-	if f < -1e308 { // -Inf
+	case math.IsInf(f, -1):
 		return append(buf, `"-Inf"`...)
 	}
-
-	// Handle negative numbers
-	if f < 0 {
-		buf = append(buf, '-')
-		f = -f
-	}
-
-	// Handle zero
-	if f == 0 {
-		return append(buf, '0')
-	}
-
-	// For very large or very small numbers, use scientific notation
-	if f >= 1e15 || (f > 0 && f < 1e-6) {
-		return appendFloatScientific(buf, f)
-	}
-
-	// Split into integer and fractional parts
-	intPart := int64(f)
-	fracPart := f - float64(intPart)
-
-	// Append integer part
-	buf = appendInt(buf, int(intPart))
-
-	// Append fractional part if non-zero (up to 6 decimal places for precision)
-	if fracPart > 0 {
-		buf = append(buf, '.')
-		// Multiply by 1000000 to get 6 decimal places
-		fracInt := int64(fracPart * 1000000)
-
-		// Format fractional part with leading zeros
-		fracBuf := [6]byte{}
-		for i := 5; i >= 0; i-- {
-			fracBuf[i] = byte(fracInt%10) + '0'
-			fracInt /= 10
-		}
-
-		// Append fractional digits, trimming trailing zeros
-		trimmed := fracBuf[:]
-		for len(trimmed) > 1 && trimmed[len(trimmed)-1] == '0' {
-			trimmed = trimmed[:len(trimmed)-1]
-		}
-		buf = append(buf, trimmed...)
-	}
-
-	return buf
-}
-
-// appendFloatScientific appends a float in scientific notation without allocations
-func appendFloatScientific(buf []byte, f float64) []byte {
-	// Calculate exponent
-	exp := 0
-	absF := f
-	if absF >= 10 {
-		for absF >= 10 {
-			absF /= 10
-			exp++
-		}
-	} else if absF < 1 && absF > 0 {
-		for absF < 1 {
-			absF *= 10
-			exp--
-		}
-	}
-
-	// Append mantissa (1 digit before decimal, 6 after)
-	intPart := int(absF)
-	buf = appendInt(buf, intPart)
-
-	fracPart := absF - float64(intPart)
-	if fracPart > 0 {
-		buf = append(buf, '.')
-		fracInt := int64(fracPart * 1000000)
-		fracBuf := [6]byte{}
-		for i := 5; i >= 0; i-- {
-			fracBuf[i] = byte(fracInt%10) + '0'
-			fracInt /= 10
-		}
-
-		// Trim trailing zeros
-		trimmed := fracBuf[:]
-		for len(trimmed) > 1 && trimmed[len(trimmed)-1] == '0' {
-			trimmed = trimmed[:len(trimmed)-1]
-		}
-		buf = append(buf, trimmed...)
-	}
-
-	// Append exponent
-	buf = append(buf, 'e')
-	if exp >= 0 {
-		buf = append(buf, '+')
-	}
-	buf = appendInt(buf, exp)
-
-	return buf
+	return strconv.AppendFloat(buf, f, 'g', -1, 64)
 }
 
 // Level defines the logging level.

--- a/bolt_test.go
+++ b/bolt_test.go
@@ -102,8 +102,9 @@ func TestJSONHandlerFields(t *testing.T) {
 	t.Run("log with float64 field", func(t *testing.T) {
 		buf.Reset()
 		logger.Info().Float64("price", 99.99).Msg("item price")
-		// Our custom formatter provides 6 decimal precision
-		expected := `{"level":"info","price":99.989999,"message":"item price"}` + "\n"
+		// strconv.AppendFloat('g', -1) emits the shortest IEEE-754
+		// round-trip representation, matching encoding/json.
+		expected := `{"level":"info","price":99.99,"message":"item price"}` + "\n"
 		if buf.String() != expected {
 			t.Errorf("Expected log output %q, got %q", expected, buf.String())
 		}

--- a/float64_test.go
+++ b/float64_test.go
@@ -4,11 +4,16 @@ package bolt
 import (
 	"bytes"
 	"math"
+	"strconv"
 	"strings"
 	"testing"
 )
 
-// TestFloat64Precision documents and validates the 6-decimal precision limitation
+// TestFloat64Precision validates that Float64 round-trips IEEE-754 values
+// without truncation. The previous fixed-point encoder lost everything
+// past 6 decimal places (e.g. pi → 3.141592). The current encoder uses
+// strconv.AppendFloat with the shortest-round-trip ('g', -1) verb,
+// matching encoding/json.
 func TestFloat64Precision(t *testing.T) {
 	var buf bytes.Buffer
 	logger := New(NewJSONHandler(&buf))
@@ -16,17 +21,17 @@ func TestFloat64Precision(t *testing.T) {
 	tests := []struct {
 		name     string
 		value    float64
-		contains string // What the output should contain
+		contains string
 	}{
 		{
 			name:     "Simple decimal",
 			value:    99.99,
-			contains: "99.989999", // 6 decimal precision
+			contains: "99.99",
 		},
 		{
-			name:     "Pi",
+			name:     "Pi (full precision)",
 			value:    3.14159265358979323846,
-			contains: "3.141592", // Truncated to 6 decimals
+			contains: "3.141592653589793",
 		},
 		{
 			name:     "Zero",
@@ -36,17 +41,22 @@ func TestFloat64Precision(t *testing.T) {
 		{
 			name:     "Negative",
 			value:    -123.456789,
-			contains: "-123.456789", // 6 decimals
+			contains: "-123.456789",
+		},
+		{
+			name:     "Seven decimals",
+			value:    1.2345678,
+			contains: "1.2345678",
 		},
 		{
 			name:     "Very large (scientific)",
 			value:    1.23e100,
-			contains: "1.23e+100", // Scientific notation
+			contains: "1.23e+100",
 		},
 		{
 			name:     "Very small (scientific)",
 			value:    1.23e-100,
-			contains: "1.23e-100", // Scientific notation
+			contains: "1.23e-100",
 		},
 		{
 			name:     "NaN",
@@ -64,9 +74,10 @@ func TestFloat64Precision(t *testing.T) {
 			contains: "\"-Inf\"",
 		},
 		{
-			name:     "Negative zero",
-			value:    math.Copysign(0, -1),
-			contains: "0", // Does not preserve negative zero sign
+			name:  "Negative zero",
+			value: math.Copysign(0, -1),
+			// strconv preserves the sign of negative zero ("-0").
+			contains: "0",
 		},
 	}
 
@@ -83,38 +94,45 @@ func TestFloat64Precision(t *testing.T) {
 	}
 }
 
-// TestFloat64VsAnyPrecision demonstrates precision difference
-func TestFloat64VsAnyPrecision(t *testing.T) {
+// TestFloat64Roundtrip verifies that non-special-case Float64 output is
+// numerically equal to the input after re-parsing (the round-trip
+// invariant strconv.AppendFloat with 'g', -1 guarantees).
+func TestFloat64Roundtrip(t *testing.T) {
 	var buf bytes.Buffer
 	logger := New(NewJSONHandler(&buf))
 
-	value := 99.99
-
-	// Float64 (6 decimal precision, zero-allocation)
-	buf.Reset()
-	logger.Info().Float64("fast", value).Msg("test")
-	float64Output := buf.String()
-
-	// Any (full precision, allocates)
-	buf.Reset()
-	logger.Info().Any("precise", value).Msg("test")
-	anyOutput := buf.String()
-
-	t.Logf("Float64 output: %s", float64Output)
-	t.Logf("Any output:     %s", anyOutput)
-
-	// Float64 should have 6-decimal representation
-	if !strings.Contains(float64Output, "99.989999") {
-		t.Errorf("Float64 should output 6-decimal precision, got: %s", float64Output)
+	cases := []float64{
+		1, 1.5, 99.99, 3.14159265358979323846,
+		-0.000123, 1e-100, 1e100, math.MaxFloat64, math.SmallestNonzeroFloat64,
 	}
-
-	// Any should have exact representation
-	if !strings.Contains(anyOutput, "99.99") {
-		t.Errorf("Any should preserve exact value, got: %s", anyOutput)
+	for _, v := range cases {
+		buf.Reset()
+		logger.Info().Float64("v", v).Msg("test")
+		// Pull the literal between the prefix and the closing comma/quote.
+		s := buf.String()
+		i := strings.Index(s, `"v":`)
+		if i < 0 {
+			t.Fatalf("missing v field in %q", s)
+		}
+		j := strings.IndexAny(s[i+4:], ",}")
+		if j < 0 {
+			t.Fatalf("malformed value in %q", s)
+		}
+		lit := s[i+4 : i+4+j]
+		got, err := strconv.ParseFloat(lit, 64)
+		if err != nil {
+			t.Fatalf("ParseFloat(%q): %v", lit, err)
+		}
+		if got != v {
+			t.Errorf("roundtrip: input %v → output %q → parsed %v", v, lit, got)
+		}
 	}
 }
 
-// TestFloat64ScientificNotation tests scientific notation formatting
+// TestFloat64ScientificNotation pins the exponent threshold strconv uses.
+// strconv 'g' picks fixed-point or exponent representation according to
+// the shortest output rule; the exact crossover differs from the old
+// hand-rolled encoder.
 func TestFloat64ScientificNotation(t *testing.T) {
 	var buf bytes.Buffer
 	logger := New(NewJSONHandler(&buf))
@@ -128,9 +146,9 @@ func TestFloat64ScientificNotation(t *testing.T) {
 		{"Large negative", -1e20, "-1e+20"},
 		{"Small positive", 1e-10, "1e-10"},
 		{"Small negative", -1e-10, "-1e-10"},
-		{"Exact threshold upper", 1e15, "1e+15"},
-		{"Exact threshold lower", 1e-6, "0.000001"}, // Just above threshold, fixed-point
-		{"Below threshold", 1e-7, "1e-7"},           // Below threshold, scientific
+		{"Just below 10^21", 1e15, "1e+15"},
+		{"1e-6", 1e-6, "1e-06"},
+		{"1e-7", 1e-7, "1e-07"},
 	}
 
 	for _, tt := range scientificTests {
@@ -146,13 +164,14 @@ func TestFloat64ScientificNotation(t *testing.T) {
 	}
 }
 
-// BenchmarkFloat64Precision benchmarks Float64 vs Any for precision tradeoff
+// BenchmarkFloat64Precision benchmarks Float64 (zero-alloc, full precision)
+// vs Any (allocates, full precision via reflection).
 func BenchmarkFloat64Precision(b *testing.B) {
 	var buf bytes.Buffer
 	logger := New(NewJSONHandler(&buf))
 	value := 3.14159265358979323846
 
-	b.Run("Float64_6decimals_zero_alloc", func(b *testing.B) {
+	b.Run("Float64_zero_alloc", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
 			buf.Reset()


### PR DESCRIPTION
## Summary

P2 batch from the multi-expert review. Closes the engineering review's #6 finding (`bolt.go:478` "silent data corruption for financial use cases") and a pre-existing classification bug for `math.MaxFloat64`.

## What's in this PR

- `appendFloat64` now delegates to `strconv.AppendFloat(buf, f, 'g', -1, 64)`, the same shortest-round-trip path `encoding/json` uses. Full IEEE-754 precision is preserved instead of being truncated to 6 decimals via `int64(fracPart * 1000000)`.
- `math.IsInf` / `math.IsNaN` replace the literal magnitude checks (`f > 1e308` mis-classified `math.MaxFloat64` as `+Inf`).
- Dead code: the custom `appendFloatScientific` helper is removed (no longer reachable).
- Tests rewritten to assert correct round-trip behaviour. New `TestFloat64Roundtrip` verifies every encoded value parses back to the exact input via `strconv.ParseFloat`.

## Why

Engineering review (#48 description, finding #6):

> **Replace custom `appendFloat64` with `strconv.AppendFloat`** — current impl loses precision (`bolt.go:478` `int64(fracPart*1e6)`) — silent data corruption for financial use cases.

Concrete examples of the data the old encoder dropped on the floor:

| input | old output | new output |
|---|---|---|
| `3.14159265358979` | `3.141592` (lost 0.65358979e-6) | `3.14159265358979` |
| `1.2345678` | `1.234567` (lost 8e-7) | `1.2345678` |
| `99.99` | `99.989999` (rep noise) | `99.99` |
| `math.MaxFloat64` | `"+Inf"` (mis-classified) | `1.7976931348623157e+308` |
| `1e-6` | `0.000001` | `1e-06` (matches encoding/json) |

## Test plan

- [x] `go build ./...` — clean
- [x] `go test -short -count=1 ./...` — all pass
- [x] `go test -race -short -count=1 .` — clean
- [x] `go test -bench=BenchmarkZeroAllocation -benchmem` — **58 ns/op, 0 allocs/op** (zero-alloc budget held)
- [x] `go test -bench=BenchmarkFloat64Precision -benchmem` — 60 ns/op, 0 allocs (was ~48 ns; the precision win costs ~12 ns)
- [x] `golangci-lint run` — 0 issues
- [x] `TestFloat64Roundtrip` (new property test) — every value round-trips via `strconv.ParseFloat`
- [ ] Wait for full CI matrix

## Behaviour change for callers

The JSON shape of float fields changes:

```diff
-{"price": 99.989999}    # old (lossy)
+{"price": 99.99}        # new (round-trip exact)

-{"value": "+Inf"}       # math.MaxFloat64 was wrongly classified
+{"value": 1.7976931348623157e+308}

-{"value": 0.000001}     # 1e-6
+{"value": 1e-06}        # matches encoding/json
```

Anything log-shipping that pinned the lossy 6-decimal shape needs to be updated. This is the same migration pinch that always lands when fixing a precision bug — short-term churn, long-term correct.