### PR TITLE
ci: benchstat-driven perf regression with statistical gating

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -52,7 +52,10 @@ jobs:
 
   performance-regression:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
@@ -68,30 +71,52 @@ jobs:
       env:
         GOTOOLCHAIN: auto
 
-    - name: Checkout base branch
+    - name: Run baseline benchmarks (base branch)
       run: |
-        git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}
+        git fetch origin ${{ github.base_ref }}
         git checkout ${{ github.base_ref }}
-
-    - name: Run baseline benchmarks
-      run: go test -run=^$ -bench=. -benchmem -count=3 -tags=bench > baseline.txt || true
-
-    - name: Checkout PR branch
-      run: git checkout ${{ github.head_ref }}
+        # 6 iterations gives benchstat enough samples for the U-test to
+        # produce meaningful p-values without blowing the CI budget.
+        go test -run=^$ -bench=. -benchmem -count=6 -tags=bench \
+          -benchtime=1s > baseline.txt 2>&1 || (cat baseline.txt; exit 1)
 
     - name: Run PR benchmarks
-      run: go test -run=^$ -bench=. -benchmem -count=3 -tags=bench > pr.txt || true
-
-    - name: Compare benchmarks
       run: |
-        if [ -f baseline.txt ] && [ -f pr.txt ]; then
-          echo "## Benchmark Comparison" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          benchstat baseline.txt pr.txt >> $GITHUB_STEP_SUMMARY 2>&1 || true
-          echo '```' >> $GITHUB_STEP_SUMMARY
-        else
-          echo "⚠️ Could not run benchmark comparison" >> $GITHUB_STEP_SUMMARY
+        git checkout ${{ github.head_ref }}
+        go test -run=^$ -bench=. -benchmem -count=6 -tags=bench \
+          -benchtime=1s > pr.txt 2>&1 || (cat pr.txt; exit 1)
+
+    - name: Compare with benchstat (Mann–Whitney U-test, alpha=0.05)
+      id: compare
+      run: |
+        # -delta-test=utest: statistical significance test instead of raw means.
+        # Output goes to BOTH the step summary (always) and a file we post as a
+        # PR comment so reviewers don't have to dig through the Actions UI.
+        benchstat -delta-test=utest baseline.txt pr.txt > delta.txt 2>&1 || true
+        echo "## Benchmark comparison (benchstat, U-test)" >> $GITHUB_STEP_SUMMARY
+        echo '```' >> $GITHUB_STEP_SUMMARY
+        cat delta.txt >> $GITHUB_STEP_SUMMARY
+        echo '```' >> $GITHUB_STEP_SUMMARY
+
+    - name: Post benchstat comment on PR
+      if: github.event_name == 'pull_request'
+      uses: marocchino/sticky-pull-request-comment@d2ad0de260ae8b0235ce059e63f2949ba9e05943 # v2.9.4
+      with:
+        header: benchstat
+        path: delta.txt
+        recreate: true
+
+    - name: Gate on statistically significant regression
+      run: |
+        # Fail the job only when the U-test reports a delta with p < 0.05
+        # AND the change is a regression (positive % delta). Insignificant
+        # noise is ignored. This stops CI from chasing flaky 1-2 ns bumps
+        # but still catches real regressions.
+        if grep -E '\+[0-9]+(\.[0-9]+)?%\s+\(p=0\.0[0-4]' delta.txt; then
+          echo "::error::Statistically significant performance regression detected (see benchstat output above)"
+          exit 1
         fi
+        echo "::notice::No statistically significant regression."
 
   allocation-check:
     runs-on: ubuntu-latest

--- a/integration_test.go
+++ b/integration_test.go
@@ -287,47 +287,38 @@ func TestEndToEndEnvironmentConfiguration(t *testing.T) {
 	})
 }
 
-// TestEndToEndPerformance tests real-world performance scenarios
-func TestEndToEndPerformance(t *testing.T) {
+// TestEndToEndHighThroughput verifies that a long run of logging operations
+// completes successfully and writes the expected number of records. The
+// previous version of this test asserted a wall-clock latency budget
+// (2.5 μs/op) which produced false positives on shared CI; latency drift
+// is now measured by the benchstat workflow with statistical significance.
+func TestEndToEndHighThroughput(t *testing.T) {
 	if testing.Short() {
-		t.Skip("Skipping performance test in short mode")
-	}
-	if raceDetectorEnabled {
-		t.Skip("Skipping performance test under -race (adds ~20x overhead)")
+		t.Skip("Skipping high-throughput test in short mode")
 	}
 
-	t.Run("High Throughput Scenario", func(t *testing.T) {
-		var buf bytes.Buffer
-		logger := New(NewJSONHandler(&buf))
+	var buf bytes.Buffer
+	logger := New(NewJSONHandler(&buf))
 
-		start := time.Now()
-		iterations := 10000
+	const iterations = 10000
+	start := time.Now()
+	for i := 0; i < iterations; i++ {
+		logger.Info().
+			Str("request_id", "req-12345").
+			Int("iteration", i).
+			Int64("timestamp", time.Now().Unix()).
+			Bool("success", true).
+			Msg("request processed")
+	}
+	duration := time.Since(start)
 
-		for i := 0; i < iterations; i++ {
-			logger.Info().
-				Str("request_id", "req-12345").
-				Int("iteration", i).
-				Int64("timestamp", time.Now().Unix()).
-				Bool("success", true).
-				Msg("request processed")
-		}
+	t.Logf("High throughput: %d iterations in %v (avg: %d ns/op)",
+		iterations, duration, duration.Nanoseconds()/int64(iterations))
 
-		duration := time.Since(start)
-		avgLatency := duration.Nanoseconds() / int64(iterations)
-
-		if avgLatency > 2500 { // 2.5μs per log (CI runners: ~1400-1540ns observed)
-			t.Errorf("Average latency too high: %d ns/op", avgLatency)
-		}
-
-		t.Logf("High throughput: %d iterations in %v (avg: %d ns/op)",
-			iterations, duration, avgLatency)
-
-		// Verify all logs were written
-		lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
-		if len(lines) != iterations {
-			t.Errorf("Expected %d log lines, got %d", iterations, len(lines))
-		}
-	})
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != iterations {
+		t.Errorf("Expected %d log lines, got %d", iterations, len(lines))
+	}
 }
 
 // TestEndToEndAllFieldTypes tests all field types in realistic scenario

--- a/performance_test.go
+++ b/performance_test.go
@@ -11,18 +11,19 @@ import (
 	"time"
 )
 
-// Performance thresholds for regression detection
-// These thresholds are set for CI shared runners (~2-3x slower than local hardware).
-// Local performance is typically ~80-100ns basic, ~200ns float64, ~350ns complex.
+// Allocation regression budget. Latency thresholds are NOT asserted here:
+// wall-clock numbers are too noisy on shared CI runners and produce false
+// positives. The benchstat-driven `performance-regression` workflow in
+// .github/workflows/pr-checks.yml does the statistical comparison
+// (Mann–Whitney U-test, alpha=0.05) instead.
 const (
-	MaxLatencyNs      = 500 // Maximum acceptable latency in nanoseconds (CI runners: ~300-360ns observed)
-	MaxAllocsPerOp    = 0   // Maximum allocations per operation (zero-allocation guarantee)
-	MaxBytesPerOp     = 200 // Maximum bytes per operation (buffer overhead)
-	Float64MaxLatency = 600 // Float64 latency threshold (CI runners: ~280-320ns observed)
+	MaxAllocsPerOp = 0   // Zero-allocation guarantee
+	MaxBytesPerOp  = 200 // Per-op buffer overhead ceiling
 )
 
-// TestPerformanceRegression ensures core performance metrics don't regress
-// Note: These tests can be flaky in CI due to GC behavior, run benchmarks for accurate results
+// TestPerformanceRegression asserts the allocation budget. Latency drift is
+// measured by the benchstat workflow, not by this test, because shared CI
+// runners produce wall-clock noise on the order of ±50%.
 func TestPerformanceRegression(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping performance regression tests in short mode")
@@ -46,11 +47,6 @@ func TestPerformanceRegression(t *testing.T) {
 		if result.AllocsPerOp() > MaxAllocsPerOp {
 			t.Errorf("Allocation regression detected: got %d allocs/op, want <= %d",
 				result.AllocsPerOp(), MaxAllocsPerOp)
-		}
-
-		if result.NsPerOp() > MaxLatencyNs {
-			t.Errorf("Latency regression detected: got %d ns/op, want <= %d",
-				result.NsPerOp(), MaxLatencyNs)
 		}
 
 		if result.AllocedBytesPerOp() > MaxBytesPerOp {
@@ -79,11 +75,6 @@ func TestPerformanceRegression(t *testing.T) {
 				result.AllocsPerOp(), MaxAllocsPerOp)
 		}
 
-		if result.NsPerOp() > Float64MaxLatency {
-			t.Errorf("Float64 latency regression detected: got %d ns/op, want <= %d",
-				result.NsPerOp(), Float64MaxLatency)
-		}
-
 		t.Logf("Float64 Performance: %d ns/op, %d B/op, %d allocs/op",
 			result.NsPerOp(), result.AllocedBytesPerOp(), result.AllocsPerOp())
 	})
@@ -109,13 +100,6 @@ func TestPerformanceRegression(t *testing.T) {
 		if result.AllocsPerOp() > MaxAllocsPerOp {
 			t.Errorf("Complex event allocation regression: got %d allocs/op, want <= %d",
 				result.AllocsPerOp(), MaxAllocsPerOp)
-		}
-
-		// Complex events may be slightly slower but still under threshold
-		maxComplexLatency := int64(2000) // Allow up to 2μs for complex events (CI runners: ~1350-1575ns observed)
-		if result.NsPerOp() > maxComplexLatency {
-			t.Errorf("Complex event latency regression: got %d ns/op, want <= %d",
-				result.NsPerOp(), maxComplexLatency)
 		}
 
 		t.Logf("Complex Event Performance: %d ns/op, %d B/op, %d allocs/op",


### PR DESCRIPTION
## Summary

P2 batch follow-up. Closes the quality review's #2 finding on flaky wall-clock latency assertions.

## What's in this PR

- `.github/workflows/pr-checks.yml` — `performance-regression` job now:
  - Runs 6 benchmark iterations on baseline (target branch) and PR (`-count=6`).
  - Compares with `benchstat -delta-test=utest` (Mann–Whitney U-test, alpha=0.05).
  - Posts a sticky PR comment with the delta table (`marocchino/sticky-pull-request-comment`).
  - Fails the job ONLY on a statistically significant regression (`p < 0.05` AND positive delta), not on routine noise.
- `performance_test.go` — drop `MaxLatencyNs` / `Float64MaxLatency` / per-subtest `maxComplexLatency` assertions. Allocation budgets (`MaxAllocsPerOp = 0`, `MaxBytesPerOp = 200`) are unchanged: those are deterministic.
- `integration_test.go` — `TestEndToEndPerformance` renamed to `TestEndToEndHighThroughput`; drops the 2500 ns/op assertion. Test still verifies that 10k iterations all write a log line.

## Why

Quality review:

> **(High) Performance assertions are wall-clock & shared-runner sensitive** — `performance_test.go:18-22` hard-codes `MaxLatencyNs=500` / `Float64MaxLatency=600`, `integration_test.go:318` asserts `< 2500ns`. GitHub free runners regularly miss this; will produce false positives or get muted into noise. No benchmark-comparison tool (benchstat) gating PRs.

The fix moves latency drift detection from a tunable-threshold-of-doom to a real statistical comparison.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test -short -count=1 ./...` — clean
- [x] `go test -count=1 -run TestPerformanceRegression .` — clean (allocation asserts still active)
- [x] `golangci-lint run` — 0 issues
- [ ] Wait for CI: the new workflow self-tests on this PR. The benchstat comparison is between target main (which has `appendFloat64 → strconv.AppendFloat` from #50) and this branch (no changes to bolt.go), so the delta table should report ~zero deltas with no significant regressions.