### PR TITLE
docs: trust scaffolding (adopters, security governance, checksums)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -67,8 +67,14 @@ announce:
   skip: false
 
 # Verification
+# SHA256 checksum file is published alongside the release artefacts so
+# downstream consumers can verify the source archive byte-for-byte. The
+# previous setting (disable: true) actively turned this protection off,
+# which is unusual for a logging library imported into every service.
 checksum:
-  disable: true
+  disable: false
+  algorithm: sha256
+  name_template: 'checksums.txt'
 
 # Source archive
 source:

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,46 @@
+# Bolt Adopters
+
+This file lists organisations and projects using bolt in production or in
+serious evaluation. The intent is honesty, not marketing — please only
+add yourself if bolt is in your dependency graph today.
+
+If you'd like to add your organisation, open a PR appending a row to the
+table below. The minimum useful entry is:
+
+- the organisation/project name
+- a short description of how bolt is used (one line)
+- (optional) a link or contact
+
+## How bolt is being used
+
+| Adopter | What for | Link |
+|---|---|---|
+| _your name here_ | _e.g. high-throughput API logging behind OTel collector_ | _optional_ |
+
+If you're considering bolt and would like to discuss it before adopting
+publicly, please open a [GitHub Discussion][disc] or file an issue.
+Sharing your migration questions in public benefits future evaluators
+even when you decide bolt isn't a fit.
+
+[disc]: https://github.com/felixgeelhaar/bolt/discussions
+
+## Why this file matters
+
+`ADOPTERS.md` is a stronger trust signal than star count. For an
+infrastructure dependency, evaluators routinely look at "who else
+trusted this with their production workload" before they ship. A
+populated `ADOPTERS.md` shortcircuits that conversation; an empty one is
+honest about where the project sits.
+
+## Governance disclosure
+
+Bolt is currently maintained by a **single maintainer** (Felix
+Geelhaar) on best-effort response time. See `SECURITY.md` for the
+formal SLA on vulnerability response and the [bolt
+roadmap](./ROADMAP.md) for what is planned.
+
+## Sponsorship
+
+If your organisation depends on bolt and would like to sponsor
+maintenance, the project accepts GitHub Sponsors via the maintainer's
+profile. Sponsorship is not required to be listed as an adopter.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,28 @@
 # Security Policy
 
+## ⚠️ Project governance and response-time disclosure
+
+Bolt is maintained by a **single maintainer** (Felix Geelhaar) under the
+MIT licence. Response times are best-effort, not contractual. The SLAs
+below describe target windows the maintainer commits to operating
+against; if a hard guarantee is required for your use case, please
+reach out before depending on bolt for incident-critical logging or
+contact the maintainer to discuss commercial support.
+
+| Concern | Target window | Notes |
+|---|---|---|
+| Acknowledge a security report | 24 hours | initial reply confirming receipt |
+| Validate / reproduce | 3 business days | preliminary triage |
+| Patch a critical vulnerability | 48 hours after validation | priority over feature work |
+| Patch a high-severity vulnerability | 7 days after validation | |
+| Patch a medium/low vulnerability | next minor release | bundled with other fixes |
+
+**Escalation path** if the standard channels do not respond within the
+target window: open a GitHub issue tagged `security` referencing the
+private advisory ID. Public escalation is the last resort, after
+private channels have lapsed. See [ADOPTERS.md](./ADOPTERS.md) for
+the broader governance posture.
+
 ## 🔒 Reporting Security Vulnerabilities
 
 **DO NOT** open public GitHub issues for security vulnerabilities.


### PR DESCRIPTION
## Summary

P3 batch — three small trust-signal items the multi-expert review flagged. Independent of larger SLSA-3 work; ships the obvious wins now.

## What's in this PR

- **`ADOPTERS.md`** — Seed file with instructions for how to add yourself, the rationale (better trust signal than star count for an infrastructure dep), and explicit governance/sponsorship posture. The empty table is honest; populating it dishonestly is worse.
- **`SECURITY.md`** — Adds top-level "Project governance and response-time disclosure" section with target windows by severity (24h ack, 3-day validate, 48h critical patch, 7d high, etc.) and escalation path. Closes a real gap for staff/principal evaluators reviewing the dependency.
- **`.goreleaser.yaml`** — Re-enable checksum publication (`disable: false`, `algorithm: sha256`, `name_template: checksums.txt`). The previous `disable: true` turned off the simplest supply-chain control. Cosign signing, SBOM, SLSA-3 provenance are tracked separately.

## Test plan

- [x] No code changes — docs + release config only
- [x] `golangci-lint run` — N/A (no Go changes)
- [ ] Wait for CI to confirm the goreleaser config still parses

## Notes for reviewers

ADOPTERS.md intentionally starts empty. Resist the urge to populate it with synthetic entries — the page renders honesty, and an honest empty table is a better adoption signal than a list of speculative use cases.