### PR TITLE
test: property-based tests via pgregory.net/rapid

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,4 +24,5 @@ require (
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	google.golang.org/protobuf v1.36.8 // indirect
+	pgregory.net/rapid v1.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -60,3 +60,5 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+pgregory.net/rapid v1.3.0 h1:vBvO0VSqti75J1jjYqpgPNBLKMd1+gxa9fYo7vk/Exc=
+pgregory.net/rapid v1.3.0/go.mod h1:dPlE4OBBxgXPqkP79flB6sJL1dx5azpI7HQ9MY9Z7uk=

--- a/property_test.go
+++ b/property_test.go
@@ -1,0 +1,190 @@
+// Property-based tests using pgregory.net/rapid.
+//
+// The expert quality review flagged that the existing string-contains
+// assertions and the 120s/week fuzz schedule miss whole classes of
+// JSON-encoding bugs. This file adds property tests that the encoder
+// must satisfy for ANY input — not just hand-picked strings.
+//
+// All properties here are roundtrip / structural invariants. They run
+// fast (a few seconds total) so they sit in the regular test suite,
+// not behind a build tag.
+package bolt
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"pgregory.net/rapid"
+)
+
+// TestRapid_StrFieldRoundtrip — for any (key, value) pair, the encoded
+// log line must be valid JSON whose decoded fields equal the input.
+// Catches: bad JSON escaping, lost code points, control-char handling,
+// and the string-contains ambiguity that handcrafted assertions hide.
+func TestRapid_StrFieldRoundtrip(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		key := rapid.StringMatching(`[a-zA-Z_][a-zA-Z0-9_]{0,30}`).Draw(t, "key")
+		value := rapid.String().Draw(t, "value")
+
+		var buf bytes.Buffer
+		logger := New(NewJSONHandler(&buf))
+		logger.Info().Str(key, value).Msg("test")
+
+		var got map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+			t.Fatalf("invalid JSON %q: %v (key=%q value=%q)", buf.String(), err, key, value)
+		}
+		if got[key] != value {
+			t.Errorf("roundtrip mismatch: key=%q got=%q want=%q", key, got[key], value)
+		}
+		if got["message"] != "test" {
+			t.Errorf("message lost: got %v", got["message"])
+		}
+		if got["level"] != "info" {
+			t.Errorf("level lost: got %v", got["level"])
+		}
+	})
+}
+
+// TestRapid_MessageRoundtrip — Msg(s) must encode the message such that
+// decoding the log line produces s exactly. The previous fuzz inputs
+// were 3-arg primitives; this property exercises arbitrary UTF-8 input
+// including surrogates, control chars, and embedded JSON-special chars.
+func TestRapid_MessageRoundtrip(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		msg := rapid.String().Draw(t, "msg")
+
+		var buf bytes.Buffer
+		logger := New(NewJSONHandler(&buf))
+		logger.Info().Msg(msg)
+
+		var got map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+			t.Fatalf("invalid JSON %q for msg=%q: %v", buf.String(), msg, err)
+		}
+		if got["message"] != msg {
+			t.Errorf("message roundtrip: got=%q want=%q", got["message"], msg)
+		}
+	})
+}
+
+// TestRapid_MultipleStrFieldsRoundtrip — chains of Str() calls must
+// produce a single valid JSON object whose decoded fields match.
+// Catches missing/extra commas in encoder, key-value pair drift.
+func TestRapid_MultipleStrFieldsRoundtrip(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		// Use distinct keys so the property is unambiguous; otherwise
+		// later fields would overwrite earlier ones in the map.
+		nFields := rapid.IntRange(1, 8).Draw(t, "n")
+		keys := make([]string, nFields)
+		values := make([]string, nFields)
+		seen := map[string]bool{}
+		for i := 0; i < nFields; i++ {
+			for {
+				k := rapid.StringMatching(`[a-zA-Z_][a-zA-Z0-9_]{0,15}`).Draw(t, "key")
+				if !seen[k] {
+					seen[k] = true
+					keys[i] = k
+					break
+				}
+			}
+			values[i] = rapid.String().Draw(t, "value")
+		}
+
+		var buf bytes.Buffer
+		logger := New(NewJSONHandler(&buf))
+		ev := logger.Info()
+		for i := range keys {
+			ev = ev.Str(keys[i], values[i])
+		}
+		ev.Msg("test")
+
+		var got map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+			t.Fatalf("invalid JSON %q: %v", buf.String(), err)
+		}
+		for i := range keys {
+			if got[keys[i]] != values[i] {
+				t.Errorf("field[%d]: key=%q got=%q want=%q", i, keys[i], got[keys[i]], values[i])
+			}
+		}
+	})
+}
+
+// TestRapid_IntFieldRoundtrip — any int produces a JSON number whose
+// decoded value matches the input.
+func TestRapid_IntFieldRoundtrip(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		key := rapid.StringMatching(`[a-zA-Z_][a-zA-Z0-9_]{0,30}`).Draw(t, "key")
+		value := rapid.Int().Draw(t, "value")
+
+		var buf bytes.Buffer
+		logger := New(NewJSONHandler(&buf))
+		logger.Info().Int(key, value).Msg("test")
+
+		var got map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+			t.Fatalf("invalid JSON %q: %v (key=%q value=%d)", buf.String(), err, key, value)
+		}
+		// json.Unmarshal decodes JSON numbers into float64 unless
+		// json.Number is requested.
+		if f, ok := got[key].(float64); !ok {
+			t.Errorf("Int field decoded as %T, want float64", got[key])
+		} else if int(f) != value {
+			t.Errorf("Int roundtrip: got=%v want=%d", f, value)
+		}
+	})
+}
+
+// TestRapid_OutputIsAlwaysValidJSON — the strongest invariant:
+// regardless of inputs, NewJSONHandler must always produce a valid JSON
+// object terminated by exactly one newline. Failure here indicates an
+// encoder bug that could break log shippers, parsers, or downstream
+// systems doing line-by-line ingest.
+func TestRapid_OutputIsAlwaysValidJSON(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		// Mix of field types and values.
+		nFields := rapid.IntRange(0, 6).Draw(t, "n")
+		var buf bytes.Buffer
+		logger := New(NewJSONHandler(&buf))
+		ev := logger.Info()
+		seen := map[string]bool{}
+		for i := 0; i < nFields; i++ {
+			var k string
+			for {
+				k = rapid.StringMatching(`[a-zA-Z_][a-zA-Z0-9_]{0,15}`).Draw(t, "key")
+				if !seen[k] {
+					seen[k] = true
+					break
+				}
+			}
+			switch rapid.IntRange(0, 3).Draw(t, "kind") {
+			case 0:
+				ev = ev.Str(k, rapid.String().Draw(t, "v"))
+			case 1:
+				ev = ev.Int(k, rapid.Int().Draw(t, "v"))
+			case 2:
+				ev = ev.Bool(k, rapid.Bool().Draw(t, "v"))
+			case 3:
+				// Float64: NaN/Inf are encoded as JSON strings, so the
+				// output is still valid JSON.
+				ev = ev.Float64(k, rapid.Float64().Draw(t, "v"))
+			}
+		}
+		ev.Msg(rapid.String().Draw(t, "msg"))
+
+		out := buf.String()
+		if !strings.HasSuffix(out, "\n") {
+			t.Errorf("output not newline-terminated: %q", out)
+		}
+		var got map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+			t.Fatalf("invalid JSON %q: %v", out, err)
+		}
+		if got["level"] != "info" {
+			t.Errorf("level missing or wrong: %v", got["level"])
+		}
+	})
+}

--- a/property_test.go
+++ b/property_test.go
@@ -114,7 +114,9 @@ func TestRapid_MultipleStrFieldsRoundtrip(t *testing.T) {
 }
 
 // TestRapid_IntFieldRoundtrip — any int produces a JSON number whose
-// decoded value matches the input.
+// decoded value matches the input. Uses json.Decoder.UseNumber() so
+// values larger than 2^53 (max safe integer in float64) round-trip
+// without precision loss.
 func TestRapid_IntFieldRoundtrip(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		key := rapid.StringMatching(`[a-zA-Z_][a-zA-Z0-9_]{0,30}`).Draw(t, "key")
@@ -124,16 +126,24 @@ func TestRapid_IntFieldRoundtrip(t *testing.T) {
 		logger := New(NewJSONHandler(&buf))
 		logger.Info().Int(key, value).Msg("test")
 
+		dec := json.NewDecoder(&buf)
+		dec.UseNumber()
 		var got map[string]any
-		if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		if err := dec.Decode(&got); err != nil {
 			t.Fatalf("invalid JSON %q: %v (key=%q value=%d)", buf.String(), err, key, value)
 		}
-		// json.Unmarshal decodes JSON numbers into float64 unless
-		// json.Number is requested.
-		if f, ok := got[key].(float64); !ok {
-			t.Errorf("Int field decoded as %T, want float64", got[key])
-		} else if int(f) != value {
-			t.Errorf("Int roundtrip: got=%v want=%d", f, value)
+		num, ok := got[key].(json.Number)
+		if !ok {
+			t.Errorf("Int field decoded as %T, want json.Number", got[key])
+			return
+		}
+		n, err := num.Int64()
+		if err != nil {
+			t.Errorf("Int field %q does not parse as int64: %v", num, err)
+			return
+		}
+		if n != int64(value) {
+			t.Errorf("Int roundtrip: got=%d want=%d", n, value)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

P2 batch follow-up. Closes the quality review's "Top 7 prioritized quality investments" item #3 (property-based JSON encoding tests).

## What's in this PR

- **`property_test.go`** — 5 rapid-based property tests covering Str / Msg / multi-field / Int / mixed-types invariants. Each asserts that encoded output is valid JSON and round-trips back to the input.
- **`go.mod` / `go.sum`** — Add `pgregory.net/rapid v1.3.0` as a test-only dependency (no production code import).

## Why

Quality review:

> **(M) Property-based tests via `pgregory.net/rapid`** for JSON escaping invariants: "encode(decode(x)) == x" for all string fields. Catches what fuzz misses.

Existing test coverage relies heavily on `strings.Contains` checks which are notoriously bad at catching encoding bugs (escape mishandling, lost code points, off-by-one in commas) — string-contains will still pass when output has extra junk before/after the substring. Property tests close that gap without adding a build tag, schedule, or CI complexity.

## Test plan

- [x] `go test -short -count=1 -run TestRapid -v .` — all 5 pass, ~1.5 ms total
- [x] `go test -short -count=1 ./...` — full suite green
- [x] `golangci-lint run` — 0 issues
- [ ] Wait for CI matrix

## Notes

- Iteration count is rapid's default (20) for fast unit-test cycle. A nightly workflow with extended iteration counts (`-rapid.checks=10000`) is deferred to a follow-up — gremlins mutation testing in the same workflow makes more sense than a standalone rapid-extended job.
- Properties intentionally only cover the JSON path (NewJSONHandler). Console handler escaping is exercised by existing handcrafted tests; adding rapid coverage there would mean parsing colour codes which is more brittle than valuable.