### PR TITLE
docs(readme): rewrite to lead with slog+otel positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,727 +1,292 @@
 # Bolt
 
 <div align="center">
-  <img src="assets/bolt_logo.png" alt="Bolt Logo" width="300"/>
-  
-  [![Build Status](https://github.com/felixgeelhaar/bolt/actions/workflows/ci.yml/badge.svg)](https://github.com/felixgeelhaar/bolt/actions/workflows/ci.yml)
-  [![Nox Security](https://github.com/felixgeelhaar/bolt/actions/workflows/nox.yml/badge.svg)](https://github.com/felixgeelhaar/bolt/actions/workflows/nox.yml)
+  <img src="assets/bolt_logo.png" alt="Bolt Logo" width="240"/>
+
+  Zero-allocation `slog.Handler` for Go with first-class OpenTelemetry.
+
+  [![Build](https://github.com/felixgeelhaar/bolt/actions/workflows/ci.yml/badge.svg)](https://github.com/felixgeelhaar/bolt/actions/workflows/ci.yml)
   [![codecov](https://codecov.io/gh/felixgeelhaar/bolt/branch/main/graph/badge.svg)](https://codecov.io/gh/felixgeelhaar/bolt)
-  [![Go Version](https://img.shields.io/badge/go-%3E%3D1.23-blue.svg)](https://golang.org/)
-  [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-  [![Go Report Card](https://goreportcard.com/badge/github.com/felixgeelhaar/bolt)](https://goreportcard.com/report/github.com/felixgeelhaar/bolt)
   [![Go Reference](https://pkg.go.dev/badge/github.com/felixgeelhaar/bolt.svg)](https://pkg.go.dev/github.com/felixgeelhaar/bolt)
-  [![Performance](https://img.shields.io/badge/performance-63ns%2Fop%20%7C%200%20allocs-brightgreen.svg)](#performance)
-  [![GitHub Pages](https://img.shields.io/badge/docs-GitHub%20Pages-blue?logo=github)](https://felixgeelhaar.github.io/bolt/)
+  [![Go Report Card](https://goreportcard.com/badge/github.com/felixgeelhaar/bolt)](https://goreportcard.com/report/github.com/felixgeelhaar/bolt)
+  [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 </div>
 
-## ⚡ Zero-Allocation Structured Logging
+## What it is
 
-Bolt is a high-performance, zero-allocation structured logging library for Go that delivers exceptional speed without compromising on features. Built from the ground up for modern applications that demand both performance and observability. Live benchmarks update automatically.
+Bolt is a high-performance structured logging library for Go. It ships
+two ways to use it:
 
-### 🚀 Performance First
+1. As a stdlib `slog.Handler` — drop into any project that already uses
+   `log/slog` and immediately get zero-allocation JSON output with
+   correct group nesting, conformance-tested against
+   `testing/slogtest.TestHandler`.
+2. As a chained-builder API for hot paths where every nanosecond and
+   allocation matters: `logger.Info().Str("k", v).Int("n", 42).Msg("…")`.
 
-| Library | Operation | ns/op | Allocations | Performance Advantage |
-|---------|-----------|-------|-------------|----------------------|
-| **Bolt** | Simple Log | **63** | **0** | **🏆 Industry Leading** |
-| **Bolt** | Float64 | **62** | **0** | **✅ Zero Allocs** |
-| **Bolt** | Uint/Int Fields | **60–75** | **0** | **✅ Zero Allocs** |
-| **Bolt** | Ints/Strs Arrays | **102–132** | **0** | **✅ Zero Allocs** |
-| **Bolt** | IPAddr (IPv4) | **100** | **0** | **✅ Zero Allocs** |
-| **Bolt** | Dict (nested object) | **170** | **0** | **✅ Zero Allocs** |
-| **Bolt** | Stringer | **91** | **0** | **✅ Zero Allocs** |
-| Zerolog | Enabled | 175 | 0 | 64% slower |
-| Zap | Enabled | 190 | 1 | 67% slower |
-| Logrus | Enabled | 2,847 | 23 | 98% slower |
+Both modes share the same encoder.
 
-*Latest benchmarks on Apple M1 with production optimizations*
+## Why bolt vs slog / zerolog / zap
 
-## ✨ Features
+A focused decision tree, not a feature shootout.
 
-- **🔥 Zero Allocations**: Achieved through intelligent event pooling, buffer reuse, and custom formatters
-- **⚡ Ultra-Fast**: 63ns/op for simple logs, 62ns for Float64, 60–170ns for all field types
-- **🏗️ Structured Logging**: Rich, type-safe field support (Int8/16/32/64, Uint8/16/32/64, Float64, Bool, Str, Ints, Strs, IPAddr, Dict, Stringer, etc.)
-- **🔍 OpenTelemetry Integration**: Automatic trace and span ID injection
-- **🎨 Multiple Outputs**: JSON for production, colorized console for development, `MultiHandler` for fan-out
-- **🪝 Hook System**: Event interception with `Hook` interface and built-in `SampleHook` for log sampling
-- **🧩 Extensible**: Custom handlers, hooks, and `NewLevelWriter` for stdlib `log` bridging
-- **🔌 slog Compatible**: Drop-in `slog.Handler` for standard library integration
-- **📦 Minimal Dependencies**: Lightweight core with optional OpenTelemetry
-- **🛡️ Type Safe**: Strongly typed field methods prevent runtime errors
-- **🔒 Security**: Input validation, JSON injection prevention, buffer limits
+| You want… | Pick |
+|---|---|
+| The standard library API, no third-party dependency, no perf budget. | `log/slog` (stdlib) |
+| Zero-alloc speed, slog ergonomics, **and** first-class OTel trace/span injection. | **bolt** |
+| The `zerolog`-style chained API with the smallest production diff and a clear migration path from existing zerolog code. | **bolt** + `docs/migrate-from-zerolog.md` |
+| `zap`'s typed-constructor API. | bolt's chained API; see `docs/migrate-from-zap.md` |
 
-## 📦 Installation
+Bolt is **not** trying to win a single-digit-nanosecond benchmark
+shootout. It's trying to be the slog handler you can ship into a
+production Go service without giving up structured perf, OTel
+correlation, or the slog ergonomics other teams already learned.
+
+## Install
 
 ```bash
 go get github.com/felixgeelhaar/bolt
 ```
 
-## 🏃 Quick Start
+Requires Go 1.24 or newer.
 
-### Basic Usage
+## Quick start
+
+### As a `slog.Handler` (recommended)
+
+```go
+package main
+
+import (
+    "log/slog"
+    "os"
+
+    "github.com/felixgeelhaar/bolt"
+)
+
+func main() {
+    logger := slog.New(bolt.NewSlogHandler(os.Stdout, nil))
+    slog.SetDefault(logger)
+
+    slog.Info("server starting", "service", "api", "port", 8080)
+}
+```
+
+`bolt.NewSlogHandler` passes the standard
+`testing/slogtest.TestHandler` conformance suite — `WithGroup`,
+`WithAttrs` scoping, empty-group elision, `LogValuer` resolution all
+work.
+
+### As a chained-builder logger (hot paths)
 
 ```go
 package main
 
 import (
     "os"
+
     "github.com/felixgeelhaar/bolt"
 )
 
 func main() {
-    // Create a JSON logger for production
-    logger := bolt.New(bolt.NewJSONHandler(os.Stdout))
-    
-    // Simple logging
-    logger.Info().Str("service", "api").Int("port", 8080).Msg("Server starting")
-    
-    // Error logging with context
-    if err := connectDatabase(); err != nil {
-        logger.Error().
-            Err(err).
-            Str("component", "database").
-            Msg("Failed to connect to database")
-    }
+    log := bolt.New(bolt.NewJSONHandler(os.Stdout))
+
+    log.Info().
+        Str("service", "api").
+        Int("port", 8080).
+        Msg("server starting")
 }
 ```
 
-### Advanced Features
+The chained API allocates zero bytes per log on the hot path. `Msg(…)`
+is the terminator — forgetting it silently drops the event (a `go vet`
+analyser is on the roadmap).
+
+### OpenTelemetry trace/span correlation
 
 ```go
-// Context-aware logging with OpenTelemetry
-contextLogger := logger.Ctx(ctx) // Automatically includes trace/span IDs
+import "github.com/felixgeelhaar/bolt"
 
-// Structured logging with rich types
-logger.Info().
-    Str("user_id", "12345").
-    Int("request_size", 1024).
+// Anywhere you have a context.Context:
+log := bolt.New(bolt.NewJSONHandler(os.Stdout))
+log.Ctx(ctx).Info().Msg("processing")
+// → {"level":"info","trace_id":"…","span_id":"…","message":"processing"}
+```
+
+`Ctx(ctx)` returns a logger that automatically attaches the active
+trace and span IDs from the context. No manual extraction.
+
+## Migrating
+
+Concrete side-by-side guides with API mapping tables, worked examples,
+and honest "when not to migrate" notes:
+
+- [`docs/migrate-from-slog.md`](./docs/migrate-from-slog.md)
+- [`docs/migrate-from-zerolog.md`](./docs/migrate-from-zerolog.md)
+- [`docs/migrate-from-zap.md`](./docs/migrate-from-zap.md)
+
+## Field types
+
+The chained API ships zero-allocation builders for the common types.
+Full reference on [`pkg.go.dev`][godoc]; this is a short tour.
+
+```go
+log.Info().
+    Str("user_id", "u-123").
+    Int("status", 200).
     Bool("authenticated", true).
-    Float64("processing_time", 0.234).
-    Time("timestamp", time.Now()).
+    Float64("latency_ms", 0.234).
+    Time("at", time.Now()).
     Dur("timeout", 30*time.Second).
-    Any("metadata", map[string]interface{}{"region": "us-east-1"}).
-    Msg("Request processed")
-
-// Create loggers with persistent context
-userLogger := logger.With().
-    Str("user_id", "12345").
-    Str("session_id", "abc-def-ghi").
-    Logger()
-
-userLogger.Info().Msg("User action logged") // Always includes user_id and session_id
-```
-
-### Array Fields, Nested Objects & IP Addresses
-
-```go
-// Integer and string arrays (zero-allocation)
-logger.Info().
-    Ints("user_ids", []int{101, 202, 303}).
+    Err(err).
+    Stringer("addr", myNetAddr).
+    Ints("user_ids", []int{1, 2, 3}).
     Strs("roles", []string{"admin", "editor"}).
-    Msg("Batch operation")
-// {"level":"info","user_ids":[101,202,303],"roles":["admin","editor"],"message":"Batch operation"}
-
-// Nested JSON objects with Dict
-logger.Info().Dict("request", func(d *bolt.Event) {
-    d.Str("method", "POST").
-        Int("status", 201).
-        Dict("headers", func(h *bolt.Event) {
-            h.Str("content-type", "application/json")
-        })
-}).Msg("API call")
-// {"level":"info","request":{"method":"POST","status":201,"headers":{"content-type":"application/json"}},"message":"API call"}
-
-// Zero-allocation IP address formatting
-logger.Info().
     IPAddr("client", net.IPv4(192, 168, 1, 100)).
-    IPAddr("server", net.IPv6loopback).
-    Msg("Connection established")
-
-// fmt.Stringer support (nil-safe)
-logger.Info().Stringer("addr", myNetAddr).Msg("Listening")
+    Dict("request", func(d *bolt.Event) {
+        d.Str("method", "POST").Int("status", 201)
+    }).
+    Msg("request handled")
 ```
 
-### Hooks & Log Sampling
+`Any(key, v)` falls back to `encoding/json` reflection — convenient,
+not zero-alloc.
+
+[godoc]: https://pkg.go.dev/github.com/felixgeelhaar/bolt
+
+## Logger composition
 
 ```go
-// Add hooks for event interception
-type MetricsHook struct{}
+// Pre-bind context that every log line should include.
+sub := log.With().
+    Str("service", "auth").
+    Str("version", "v1.2.3").
+    Logger()
 
-func (h *MetricsHook) Run(level bolt.Level, msg string) bool {
+sub.Info().Str("user", uid).Msg("login")
+// → includes service, version, user every time
+```
+
+## Hooks and sampling
+
+```go
+// Hooks run before the event is written; returning false drops it.
+type metricsHook struct{}
+func (h *metricsHook) Run(level bolt.Level, msg string) bool {
     metrics.IncrementLogCounter(level.String())
-    return true // return false to suppress the event
+    return true
 }
+log.AddHook(&metricsHook{})
 
-logger := bolt.New(bolt.NewJSONHandler(os.Stdout)).
-    AddHook(&MetricsHook{})
-
-// Built-in sampling: log only 1 out of every 100 events
-logger = bolt.New(bolt.NewJSONHandler(os.Stdout)).
-    AddHook(bolt.NewSampleHook(100))
+// Built-in: keep 1 of every N events at the same level.
+log.AddHook(bolt.NewSampleHook(100))
 ```
 
-### Multi-Output & stdlib Bridging
+The current `Hook` interface only sees level and message. A richer
+`*Event`-aware hook interface is on the roadmap (see `ROADMAP.md`).
+
+## Multi-output
 
 ```go
-// Fan-out to multiple destinations
-logger := bolt.New(bolt.MultiHandler(
-    bolt.NewJSONHandler(logFile),       // Structured logs to file
-    bolt.NewConsoleHandler(os.Stderr),  // Human-readable to terminal
+log := bolt.New(bolt.MultiHandler(
+    bolt.NewJSONHandler(logFile),       // structured to file
+    bolt.NewConsoleHandler(os.Stderr),  // colourised to terminal
 ))
+```
 
-// Bridge stdlib log package into Bolt
-w := bolt.NewLevelWriter(logger, bolt.ERROR)
+## Console output for development
+
+```go
+log := bolt.New(bolt.NewConsoleHandler(os.Stdout))
+log.Info().Str("env", "development").Int("workers", 4).Msg("ready")
+// → INFO[2026-05-09T10:30:45Z] ready env=development workers=4
+```
+
+## Production tips (`<details>`)
+
+<details>
+<summary><strong>Levels and runtime configuration</strong></summary>
+
+```go
+log := bolt.New(bolt.NewJSONHandler(os.Stdout)).SetLevel(bolt.LevelInfo)
+
+// Environment overrides:
+//   BOLT_LEVEL  = trace | debug | info | warn | error | fatal
+//   BOLT_FORMAT = json | console
+```
+
+The slog-style aliases (`bolt.LevelInfo`, `LevelError`, …) and the
+SCREAMING_CASE forms (`bolt.INFO`, `ERROR`, …) are interchangeable.
+
+</details>
+
+<details>
+<summary><strong>Thread-safety contract</strong></summary>
+
+`JSONHandler`, `ConsoleHandler`, and `SlogHandler` all serialise writes
+internally via `sync.Mutex`, so a single handler is safe for concurrent
+use across goroutines. Custom handlers are responsible for their own
+synchronisation.
+
+</details>
+
+<details>
+<summary><strong>Fatal semantics</strong></summary>
+
+`logger.Fatal()` writes the record and then calls `os.Exit(1)`,
+matching `zap`, `zerolog`, `logrus`, and `slog` ecosystem norms. To
+test code paths that emit Fatal records without terminating the test
+binary, override the unexported `exitFunc` package variable (see
+`fatal_test.go` for the pattern).
+
+</details>
+
+<details>
+<summary><strong>Stdlib log bridge</strong></summary>
+
+```go
+w := bolt.NewLevelWriter(log, bolt.LevelError)
 stdlog := log.New(w, "", 0)
-stdlog.Print("stdlib error message") // Logged as Bolt ERROR level
-
-// CallerSkip for wrapper functions
-func myLogWrapper(logger *bolt.Logger, msg string) {
-    logger.Info().CallerSkip(1).Msg(msg) // Reports caller of myLogWrapper
-}
+stdlog.Print("legacy error path") // → bolt ERROR
 ```
 
-### Console Output for Development
+</details>
 
-```go
-// Pretty console output for development
-logger := bolt.New(bolt.NewConsoleHandler(os.Stdout))
+## Examples
 
-logger.Info().
-    Str("env", "development").
-    Int("workers", 4).
-    Msg("Application initialized")
+Each `examples/` subdirectory is a standalone Go module so you can
+clone, `cd` into one, and `go run .`. CI builds every example listed
+on every PR.
 
-// Output: [2024-01-15T10:30:45Z] INFO Application initialized env=development workers=4
-```
+| Example | What it shows |
+|---|---|
+| `rest-api/` | HTTP service with structured access logs |
+| `grpc-service/` | gRPC server with structured request/response logs |
+| `microservices/http-middleware/` | Middleware-style HTTP logging with correlation IDs |
+| `microservices/grpc-interceptors/` | gRPC interceptors (requires regenerating proto stubs) |
+| `observability/opentelemetry/` | OTel tracing + Prometheus metrics + bolt log correlation |
+| `batch-processor/` | Worker-pool / fan-out batching with sampling |
 
-### Standard Library slog Integration
+See [`examples/README.md`](./examples/README.md) for the full table and
+the roadmap of patterns under consideration.
 
-Use Bolt as a backend for Go's standard `log/slog` package:
+## Roadmap and governance
 
-```go
-import (
-    "log/slog"
-    "os"
-    "github.com/felixgeelhaar/bolt"
-)
+- [`ROADMAP.md`](./ROADMAP.md) — current themes (trust, positioning,
+  migrator ergonomics, production correctness, supply-chain hardness),
+  P0–P4 task table, and explicitly out-of-scope items.
+- [`SECURITY.md`](./SECURITY.md) — vulnerability reporting and
+  response-time SLAs (solo maintainer, MIT, best-effort).
+- [`ADOPTERS.md`](./ADOPTERS.md) — list of organisations using bolt;
+  PRs welcome.
+- [`CHANGELOG.md`](./CHANGELOG.md) — release notes.
 
-func main() {
-    // Create a Bolt-powered slog handler
-    handler := bolt.NewSlogHandler(os.Stdout, nil)
-    logger := slog.New(handler)
+## Contributing
 
-    logger.Info("request handled",
-        "method", "GET",
-        "status", 200,
-        "path", "/api/users",
-    )
-    // Output: {"time":"...","level":"INFO","msg":"request handled","method":"GET","status":200,"path":"/api/users"}
+Issues and PRs welcome. See `CONTRIBUTING.md` for the workflow. The
+short version: open an issue first for non-trivial changes,
+conventional-commits format for messages, signed commits to `main`.
 
-    // With level filtering
-    handler = bolt.NewSlogHandler(os.Stdout, &bolt.SlogHandlerOptions{
-        Level: slog.LevelWarn,
-    })
-    warnLogger := slog.New(handler)
-    warnLogger.Info("filtered out") // suppressed
-    warnLogger.Warn("visible")     // appears
-}
-```
+## License
 
-### Choosing a Handler
-
-| Handler | Use Case | Allocations | Best For |
-|---------|----------|-------------|----------|
-| **JSONHandler** | Production logging | 0 allocs/op | High-throughput services, log aggregation |
-| **ConsoleHandler** | Development | ~10 allocs/op | Local development, debugging |
-| **SlogHandler** | stdlib compatibility | 2 allocs/op | Teams using `log/slog`, gradual migration |
-| **MultiHandler** | Fan-out to multiple destinations | 0 allocs/op | Writing to file + console, log aggregation pipelines |
-
-**Recommendation**: Use `JSONHandler` directly for maximum performance. Use `SlogHandler` when you need compatibility with the `log/slog` ecosystem or are migrating from another `slog.Handler` implementation.
-
-## 🏗️ Architecture Insights
-
-### Zero-Allocation Design
-
-Bolt achieves zero allocations through several key innovations:
-
-1. **Event Pooling**: Reuses event objects via `sync.Pool`
-2. **Buffer Management**: Pre-allocated buffers with intelligent growth
-3. **Direct Serialization**: Numbers and primitives written directly to buffers
-4. **String Interning**: Efficient string handling without unnecessary copies
-
-### Performance Optimizations
-
-- **Fast Number Conversion**: Custom integer-to-string functions optimized for common cases
-- **Allocation-Free RFC3339**: Custom timestamp formatting without `time.Format()` allocations
-- **Intelligent Buffering**: Buffers sized to minimize reallocations for typical log entries
-- **Branch Prediction**: Code structured to optimize for common execution paths
-
-## 🎯 Production Usage
-
-### Environment-Based Configuration
-
-```go
-// Automatic format selection based on environment
-logger := bolt.New(bolt.NewJSONHandler(os.Stdout))
-
-// Set via environment variables:
-// BOLT_LEVEL=info
-// BOLT_FORMAT=json (production) or console (development)
-```
-
-### OpenTelemetry Integration
-
-```go
-import (
-    "context"
-    "go.opentelemetry.io/otel"
-    "github.com/felixgeelhaar/bolt"
-)
-
-func handleRequest(ctx context.Context) {
-    // Trace and span IDs automatically included
-    logger := baseLogger.Ctx(ctx)
-    
-    logger.Info().
-        Str("operation", "user.create").
-        Msg("Processing user creation")
-        
-    // Logs will include:
-    // {"level":"info","trace_id":"4bf92f3577b34da6a3ce929d0e0e4736","span_id":"00f067aa0ba902b7","operation":"user.create","message":"Processing user creation"}
-}
-```
-
-## 📊 Benchmarks
-
-### Running Bolt's Internal Benchmarks
-
-Test Bolt's performance on your system:
-
-```bash
-# Run Bolt's internal performance tests
-go test -bench=. -benchmem
-
-# Run specific benchmarks
-go test -bench=BenchmarkZeroAllocation -benchmem
-go test -bench=BenchmarkFloat64 -benchmem
-```
-
-### Comparing Against Other Libraries
-
-Comparison benchmarks (Bolt vs Zerolog vs Zap vs slog) are maintained in a separate module to avoid adding unnecessary dependencies for users. To run comparison benchmarks:
-
-```bash
-cd benchmarks
-go test -bench=. -benchmem
-
-# Compare specific libraries
-go test -bench=BenchmarkBolt -benchmem
-go test -bench=BenchmarkZerolog -benchmem
-go test -bench=BenchmarkZap -benchmem
-go test -bench=BenchmarkSlog -benchmem
-```
-
-See [benchmarks/README.md](benchmarks/README.md) for detailed instructions.
-
-### Sample Results
-
-```
-BenchmarkZeroAllocation-8            13,483,334     87 ns/op      0 B/op    0 allocs/op
-BenchmarkFloat64Precision-8          18,972,231     62 ns/op      0 B/op    0 allocs/op
-BenchmarkNewFieldMethods/Int32-8     20,163,957     60 ns/op      0 B/op    0 allocs/op
-BenchmarkConsoleHandler-8             2,427,907    491 ns/op    144 B/op   10 allocs/op
-BenchmarkDefaultLogger-8             12,723,752    106 ns/op    168 B/op    0 allocs/op
-BenchmarkSlogHandler-8                  822,313  1,458 ns/op    384 B/op    2 allocs/op
-```
-
-**Note**: ConsoleHandler has ~10 allocations due to colorization. SlogHandler's 2 allocations come from slog's own `Record` creation. Use JSONHandler for zero-allocation production logging.
-
-## 🛡️ Security Features
-
-Bolt includes multiple security features to protect against common logging vulnerabilities:
-
-### Input Validation & Sanitization
-
-```go
-// Automatic input validation prevents log injection attacks
-logger.Info().
-    Str("user_input", userProvidedData).  // Automatically JSON-escaped
-    Msg("User data logged safely")
-
-// Built-in size limits prevent resource exhaustion
-// - Keys: max 256 characters
-// - Values: max 64KB
-// - Total buffer: max 1MB per log entry
-```
-
-### Thread Safety
-
-```go
-// All operations are thread-safe with atomic operations
-var logger = bolt.New(bolt.NewJSONHandler(os.Stdout))
-
-// Safe to use across multiple goroutines
-go func() {
-    logger.SetLevel(bolt.DEBUG) // Thread-safe level changes
-}()
-
-go func() {
-    logger.Info().Msg("Concurrent logging") // Safe concurrent access
-}()
-```
-
-### Error Handling
-
-```go
-// Comprehensive error handling with custom error handlers
-logger := bolt.New(bolt.NewJSONHandler(os.Stdout)).
-    SetErrorHandler(func(err error) {
-        // Custom error handling logic
-        fmt.Fprintf(os.Stderr, "Logging error: %v\n", err)
-    })
-```
-
-### Security Best Practices
-
-- **No eval() or injection vectors**: All data is properly escaped during JSON serialization
-- **Memory safety**: Buffer size limits prevent unbounded memory usage
-- **Structured output**: JSON format prevents log format injection
-- **Controlled serialization**: Type-safe field methods prevent data corruption
-
-## 🔧 Custom Handlers
-
-Extend Bolt with custom output formats:
-
-```go
-type CustomHandler struct {
-    output io.Writer
-}
-
-func (h *CustomHandler) Write(e *bolt.Event) error {
-    // Custom formatting logic
-    formatted := customFormat(e)
-    _, err := h.output.Write(formatted)
-    return err
-}
-
-logger := bolt.New(&CustomHandler{output: os.Stdout})
-```
-
-## 🔍 Troubleshooting
-
-### Common Issues and Solutions
-
-#### Performance Issues
-
-**Symptom**: Logging is slower than expected
-```bash
-# Check if you're in debug mode accidentally
-echo $BOLT_LEVEL  # Should be 'info' or 'warn' for production
-
-# Run benchmarks to compare
-go test -bench=BenchmarkZeroAllocation -benchmem
-```
-
-**Symptom**: Memory usage is high
-```go
-// Ensure you're calling Msg() to complete log entries
-logger.Info().Str("key", "value")  // ❌ Event not completed
-logger.Info().Str("key", "value").Msg("message")  // ✅ Proper completion
-
-// Check for event leaks in error handling
-if err != nil {
-    // ❌ This leaks events if err is always nil
-    logger.Error().Err(err).Msg("error occurred")  
-}
-
-if err != nil {
-    // ✅ Proper conditional logging
-    logger.Error().Err(err).Msg("error occurred")
-}
-```
-
-#### Thread Safety Issues
-
-**Symptom**: Race conditions detected
-```bash
-# Run tests with race detector
-go test -race ./...
-
-# The library itself is thread-safe, but output destinations may not be
-# Use thread-safe output for concurrent scenarios
-```
-
-**Solution**: Use thread-safe outputs
-```go
-// ❌ bytes.Buffer is not thread-safe
-var buf bytes.Buffer
-logger := bolt.New(bolt.NewJSONHandler(&buf))
-
-// ✅ Use thread-safe alternatives
-type SafeBuffer struct {
-    buf bytes.Buffer
-    mu  sync.Mutex
-}
-
-func (sb *SafeBuffer) Write(p []byte) (n int, err error) {
-    sb.mu.Lock()
-    defer sb.mu.Unlock()
-    return sb.buf.Write(p)
-}
-```
-
-#### Configuration Issues
-
-**Symptom**: Logs not appearing
-```go
-// Check log level configuration
-logger := bolt.New(bolt.NewJSONHandler(os.Stdout))
-logger.SetLevel(bolt.ERROR)  // Will suppress Info/Debug logs
-
-logger.Debug().Msg("Debug message")  // Won't appear
-logger.Error().Msg("Error message")  // Will appear
-```
-
-**Symptom**: Wrong output format
-```bash
-# Check environment variables
-echo $BOLT_FORMAT  # Should be 'json' or 'console'
-echo $BOLT_LEVEL   # Should be valid level name
-
-# Override with code if needed
-logger := bolt.New(bolt.NewConsoleHandler(os.Stdout)).SetLevel(bolt.DEBUG)
-```
-
-#### Integration Issues
-
-**Symptom**: OpenTelemetry traces not appearing
-```go
-// Ensure context contains valid span
-span := trace.SpanFromContext(ctx)
-if !span.SpanContext().IsValid() {
-    // No active span in context
-    logger.Info().Msg("No trace context")
-}
-
-// Use context-aware logger
-ctxLogger := logger.Ctx(ctx)
-ctxLogger.Info().Msg("With trace context")
-```
-
-#### Performance Debugging
-
-```bash
-# Profile memory usage
-go test -bench=BenchmarkZeroAllocation -memprofile=mem.prof
-go tool pprof mem.prof
-
-# Profile CPU usage  
-go test -bench=BenchmarkZeroAllocation -cpuprofile=cpu.prof
-go tool pprof cpu.prof
-
-# Check for allocations
-go test -bench=. -benchmem | grep allocs
-```
-
-### Getting Help
-
-1. **Check the documentation**: Review API documentation and examples
-2. **Run diagnostics**: Use built-in benchmarks and race detection
-3. **Community support**: Open GitHub issues with minimal reproduction cases
-4. **Security issues**: Follow responsible disclosure in [SECURITY.md](SECURITY.md)
-
-## ⚠️ Limitations & Considerations
-
-### When Bolt is Ideal
-
-✅ **Perfect for:**
-- High-throughput APIs (>10k req/sec)
-- Microservices with strict latency requirements
-- Applications requiring GC-friendly logging
-- Production systems where performance is critical
-- Containerized/cloud-native deployments
-
-### Known Limitations
-
-❌ **Not suitable for:**
-- **Real-time systems with <10µs latency requirements** - Bolt's 60-300ns overhead may be significant
-- **Extreme memory constraints (<1MB heap)** - Event pool requires ~8-64KB overhead
-- **Non-Go applications** - Bolt is Go-specific
-- **Legacy log parsers** - Requires JSON-compatible log processors
-
-### Performance Characteristics
-
-| Scenario | Overhead | Notes |
-|----------|----------|-------|
-| Simple log (3 fields) | ~63ns | 0 allocations |
-| Float64 field | ~62ns | 0 allocations |
-| Uint/Int fields | ~60ns | 0 allocations |
-| Ints/Strs arrays | ~102–132ns | 0 allocations |
-| IPAddr (IPv4) | ~100ns | 0 allocations |
-| Dict (nested object) | ~170ns | 0 allocations |
-| Stringer | ~91ns | 0 allocations |
-| Console handler | ~491ns | 10 allocations (acceptable for dev) |
-| HTTP request logging | ~0.01% CPU | Negligible impact |
-| High throughput (100k/sec) | <1% CPU | Scales linearly |
-
-**Memory Profile:**
-- Event pool: 8-64KB (steady state)
-- Per-event: ~336 bytes (pooled, reused)
-- Production API (50k req/sec): ~2-4MB total
-
-See [GitHub Pages](https://felixgeelhaar.github.io/bolt/) for live benchmarks and performance analysis.
-
-## 🚀 Deployment Guide
-
-### Production Deployment
-
-#### 1. Kubernetes
-
-```yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: bolt-app
-spec:
-  template:
-    spec:
-      containers:
-      - name: app
-        image: myapp:latest
-        env:
-        - name: LOG_FORMAT
-          value: "json"
-        - name: LOG_LEVEL
-          value: "info"
-        - name: OTEL_EXPORTER_OTLP_ENDPOINT
-          value: "http://otel-collector:4317"
-```
-
-📖 **Full example**: See [examples/kubernetes/](examples/kubernetes/)
-
-#### 2. Cloud Platforms
-
-**AWS Lambda:**
-```go
-logger := bolt.New(bolt.NewJSONHandler(os.Stdout)).With().
-    Str("function", os.Getenv("AWS_LAMBDA_FUNCTION_NAME")).
-    Str("region", os.Getenv("AWS_REGION")).
-    Logger()
-```
-
-**Google Cloud Run:**
-```go
-logger := bolt.New(bolt.NewJSONHandler(os.Stdout)).With().
-    Str("service", os.Getenv("K_SERVICE")).
-    Str("revision", os.Getenv("K_REVISION")).
-    Logger()
-```
-
-**Azure Functions:**
-```go
-logger := bolt.New(bolt.NewJSONHandler(os.Stdout)).With().
-    Str("function", os.Getenv("WEBSITE_SITE_NAME")).
-    Logger()
-```
-
-📖 **More examples**: See [examples/](examples/) directory for additional cloud platform integrations
-
-#### 3. Framework Integration
-
-**Gin:**
-```go
-r.Use(BoltLogger(logger))
-```
-
-**Echo:**
-```go
-e.Use(BoltLoggerWithTracing(logger))
-```
-
-**Fiber:**
-```go
-app.Use(BoltLogger(logger))
-```
-
-**Chi:**
-```go
-r.Use(BoltLogger(logger))
-```
-
-📖 **Framework integration**: See [examples/microservices/](examples/microservices/) for middleware examples
-
-### Production Checklist
-
-- [ ] Use JSON handler (zero allocations)
-- [ ] Set appropriate log level (info/warn for production)
-- [ ] Configure OpenTelemetry for distributed tracing
-- [ ] Set up log aggregation (Fluentd, Fluent Bit, etc.)
-- [ ] Enable monitoring (Prometheus, Grafana)
-- [ ] Configure health checks and metrics endpoints
-- [ ] Test graceful shutdown and log flushing
-- [ ] Validate security (no sensitive data in logs)
-- [ ] Set resource limits (memory, CPU)
-- [ ] Enable alerting on error rates
-
-📖 **Production examples**: See [examples/](examples/) directory
-
-## 📚 Documentation
-
-### Core Documentation
-- [📖 **Live Benchmarks**](https://felixgeelhaar.github.io/bolt/) - Real-time performance metrics
-- [🏗️ **API Documentation**](https://pkg.go.dev/github.com/felixgeelhaar/bolt) - Complete API reference
-- [🎯 **Production Examples**](examples/) - REST API, gRPC, Batch processing, K8s
-- [📊 **Observability**](examples/observability/) - OpenTelemetry, Prometheus integration
-
-### Integration Guides
-- Framework examples: [Gin](examples/microservices/http-middleware), [gRPC](examples/grpc-service)
-- Cloud deployments: [Kubernetes](examples/kubernetes/), [Batch Processing](examples/batch-processor/)
-- Monitoring setup: [Prometheus](examples/observability/prometheus/), [OpenTelemetry](examples/observability/opentelemetry/)
-
-### Community Guidelines
-- [🤝 **Contributing**](CONTRIBUTING.md) - How to contribute to Bolt
-- [🛡️ **Security Policy**](SECURITY.md) - Security vulnerability reporting
-- [📜 **Code of Conduct**](CODE_OF_CONDUCT.md) - Community standards
-
-## 🤝 Contributing
-
-We welcome contributions! **Please fork the repository** and submit pull requests from your fork.
-
-### Quick Start for Contributors
-
-1. **Fork** this repository on GitHub
-2. **Clone** your fork:
-   ```bash
-   git clone https://github.com/YOUR_USERNAME/bolt.git
-   cd bolt
-   ```
-3. **Create a feature branch**:
-   ```bash
-   git checkout -b feature/your-feature-name
-   ```
-4. **Make your changes** and ensure tests pass:
-   ```bash
-   go test ./...
-   go test -bench=. -benchmem
-
-   # Optional: Run comparison benchmarks
-   cd benchmarks && go test -bench=. -benchmem
-   ```
-5. **Submit a pull request** from your fork
-
-📖 **Detailed guidelines**: See [CONTRIBUTING.md](CONTRIBUTING.md) for complete contribution workflow, coding standards, and performance requirements.
-
-## 📄 License
-
-MIT License - see [LICENSE](LICENSE) file for details.
-
-## 🎖️ Recognition
-
-Bolt draws inspiration from excellent logging libraries like Zerolog and Zap, while pushing the boundaries of what's possible in Go logging performance.
-
----
-
-<div align="center">
-  <img src="assets/bolt_logo.png" alt="Bolt Icon" width="64"/>
-  
-  **Built with ❤️ for high-performance Go applications**
-</div>
+MIT. See [`LICENSE`](./LICENSE).


### PR DESCRIPTION
## Summary

P1 follow-up. Closes the multi-expert review's #1 friction point: a 727-line README where the hero was buried, no decision section answered "why not stdlib slog?", and the slog example sat below an enterprise-grade-everything claim list that no contributor was asked to back up.

## What's in this PR

- **`README.md`** — full rewrite, 727 → 292 lines.
  - Hero (12 lines): "Zero-allocation `slog.Handler` for Go with first-class OpenTelemetry."
  - "Why bolt vs slog / zerolog / zap" decision table above the fold; explicit `pick stdlib slog if no perf budget`.
  - Quick start shows BOTH the slog handler entry point (recommended) AND the chained API (hot paths).
  - Migration guides linked, not inlined.
  - Production tips (levels, thread-safety, Fatal semantics, stdlib log bridge) folded into `<details>` blocks so first impression stays light.
  - Roadmap / governance / adopters / contributing each linked in one line.
  - Drops the inline deployment-and-troubleshooting matrix, the speculative benchmark claims that don't match shared-CI reality, and the sub-100 ns marketing badge.

## Why

UX review:

> **README is ~730 lines, hero+features alone scroll past 50 lines.** Miller's 7±2 violated — Quick Start, Advanced, Arrays, Hooks, Multi, Console, slog, Architecture, Production, Benchmarks, Security, Custom, Troubleshooting, Limitations, Deployment, Docs, Contributing all on one page.

GTM review:

> **No objection handling vs `log/slog`.** The single biggest competitive alternative for any new Go service in 2026 is the stdlib. README never directly answers "why not just use slog?" — the SlogHandler is sold as a *compatibility* feature, not a wedge.

This rewrite addresses both: the slog handler is the lead, and the decision section above the fold tells visitors when they should pick the stdlib instead.

## Test plan

- [x] No code changes; rendered the markdown locally to verify `<details>` blocks collapse correctly on github.com.
- [x] All cross-links target real files: `docs/migrate-from-*.md`, `examples/README.md`, `ROADMAP.md`, `SECURITY.md`, `ADOPTERS.md`, `CHANGELOG.md`, `LICENSE`, `CONTRIBUTING.md`.
- [ ] Wait for CI (no Go changes, only validate-pr / lint relevant).

## Notes

The `<details>`-folded production tips remain in this README rather than moving to the docs site. Reasoning: those four sections (levels/env vars, thread-safety, Fatal semantics, stdlib log bridge) answer questions production reviewers ask in PR comments, and putting them one click away (open the `<details>`) is friendlier than two clicks (open the docs site, navigate to the page).

The Diataxis docs-site restructure is tracked separately in `ROADMAP.md` (P3).