### PR TITLE
docs(examples): add readmes for otel + grpc-interceptors examples

### DIFF
--- a/examples/microservices/grpc-interceptors/README.md
+++ b/examples/microservices/grpc-interceptors/README.md
@@ -1,0 +1,43 @@
+# gRPC interceptors example
+
+A reference for adding bolt structured logs to a gRPC server through
+unary and stream interceptors. Demonstrates request correlation,
+duration measurement, error capture, and per-RPC log scoping.
+
+## Status: requires proto regeneration
+
+This example imports generated protobuf stubs (e.g.
+`pb.UserServiceServer`) that are not committed to the repo. To run
+it, regenerate the stubs first:
+
+```bash
+cd examples/microservices/grpc-interceptors
+protoc --go_out=. --go-grpc_out=. user_service.proto
+go mod tidy
+go run .
+```
+
+This requirement is the reason the project's CI explicitly skips
+building this directory. The `main.go` and `user_service.proto` are
+intended as a starting template, not a turnkey demo.
+
+## What the interceptors show
+
+- A unary interceptor that:
+  - generates a correlation ID per RPC
+  - logs request start with method name, peer address, deadline
+  - measures duration with `time.Since` and emits a structured log on
+    completion or error
+  - enriches the per-RPC logger via `Logger.With()` so any handler
+    code that needs to log can do so without rewriting the chain
+- A stream interceptor that wraps `grpc.ServerStream` to log Send/Recv
+  framing events without changing the application protocol.
+
+## Where bolt fits
+
+The interceptors do not introduce a custom logger interface — they
+take a `*bolt.Logger` directly. This keeps the call site small and
+avoids the indirection that often grows around middleware.
+
+For an HTTP-flavoured equivalent without proto-stub setup, see
+[`../http-middleware`](../http-middleware/).

--- a/examples/observability/opentelemetry/README.md
+++ b/examples/observability/opentelemetry/README.md
@@ -1,0 +1,51 @@
+# OpenTelemetry observability example
+
+The flagship integration example: an HTTP service wired to OpenTelemetry
+tracing (OTLP exporter), Prometheus metrics, and bolt structured logs
+correlated by trace and span ID.
+
+## Run it
+
+```bash
+cd examples/observability/opentelemetry
+go mod tidy
+go run .
+```
+
+The server listens on `:8080` and exports traces to `localhost:4318`
+via OTLP/HTTP. To see traces, run a collector that accepts that
+endpoint (Jaeger, Tempo, OTel Collector, etc.). Set `OTLP_ENDPOINT`
+to override.
+
+## What it shows
+
+- `bolt.NewJSONHandler` writing structured logs to stdout
+- `Logger.With()` to bind service-level fields once (`service`, `version`)
+- Per-request correlation via the existing trace and span IDs from the
+  active OTel context, attached as `trace_id` and `span_id` log fields
+- Counter / histogram / gauge metrics on the same handler chain
+- Honest error path: an `/error` endpoint emits both a recorded error
+  span and an `Error` log line so log+trace correlation can be seen
+  end-to-end
+
+## Endpoints
+
+| Path | What |
+|---|---|
+| `/` | Records a span, sleeps a bit, logs request lifecycle |
+| `/users` | Calls a child span "db_query_users" with a 10% simulated failure rate |
+| `/error` | Always returns 500 with a recorded span error and an Error log |
+| `/health` | Liveness probe |
+| `/metrics` | Prometheus scrape endpoint |
+
+## Where bolt fits
+
+bolt is the log layer; OTel is the trace + metric layer. The example
+treats the two as complementary — logs carry the same correlation IDs
+the traces do, so a log shipper like Loki + Grafana can jump from a log
+line to the trace it belongs to (or back) without bespoke glue.
+
+For the API mapping if you're migrating from a different logger, see
+[`docs/migrate-from-zerolog.md`](../../../docs/migrate-from-zerolog.md),
+[`docs/migrate-from-zap.md`](../../../docs/migrate-from-zap.md), or
+[`docs/migrate-from-slog.md`](../../../docs/migrate-from-slog.md).


### PR DESCRIPTION
## Summary

P1 cleanup. Two flagship examples were missing READMEs entirely.

## What's in this PR

- `examples/observability/opentelemetry/README.md` — explains the OTel + Prometheus + bolt correlation model, lists endpoints, points at migration guides.
- `examples/microservices/grpc-interceptors/README.md` — documents the proto-regeneration requirement (which explains the CI skip), describes the interceptor pattern, points at the `http-middleware` sibling for a no-proto walkthrough.

Each README is ~30 lines. The quality review wanted "one-paragraph per example", not the 200–700 line essays that some older examples ship with. Trimming the existing oversized READMEs is tracked separately on the roadmap.

## Test plan

- [x] No code changes
- [ ] Wait for CI (only `validate-pr` / `lint` relevant)