### PR TITLE
feat(genai): redacthook + adaptivesampler eventhook helpers

### DIFF
--- a/genai/README.md
+++ b/genai/README.md
@@ -117,6 +117,56 @@ arguments / result body. Tool calls routinely contain user-supplied
 data — logging the body unconditionally is a PII trap. Bring your own
 redaction hook (`bolt.AddEventHook`) if you want the contents.
 
+## Pre-built EventHooks
+
+Two hooks ship with this package for the most common AI workload
+concerns identified in the multi-expert review.
+
+### Redaction (deny-list suppression)
+
+```go
+log := bolt.New(bolt.NewJSONHandler(os.Stdout)).
+    AddEventHook(genai.NewRedactHook())  // uses genai.DefaultDenyKeys
+
+// Drops any event with a "prompt", "completion", "messages", "input",
+// "output", "api_key", "token", or "authorization" field.
+```
+
+Pass a custom list to override the defaults:
+
+```go
+log.AddEventHook(genai.NewRedactHook("internal_secret", "session_id"))
+```
+
+The hook **suppresses** the event entirely — it does not redact in
+place (bolt's `EventHook` contract is read-only). If you need a
+sanitised variant of the event to ship anyway, log it explicitly
+before the sensitive event reaches the hook.
+
+### Adaptive sampling (always keep gen_ai + errors)
+
+```go
+log := bolt.New(bolt.NewJSONHandler(os.Stdout)).
+    AddEventHook(genai.NewAdaptiveSampler(100))
+
+// Keeps every event whose level is >= ERROR, every event whose fields
+// include any "gen_ai.*" key, and 1 of every 100 other events.
+```
+
+Token-stream debug logs are typically 10–100× the volume of the
+structured GenAI breadcrumbs that downstream tools (Langfuse / Phoenix
+/ Braintrust) actually want. `AdaptiveSampler` lets you sample the
+noise without losing the breadcrumbs.
+
+The defaults are configurable on the returned struct:
+
+```go
+s := genai.NewAdaptiveSampler(100)
+s.AlwaysKeepLevel = bolt.LevelWarn   // also keep WARN and above
+s.AlwaysKeepPrefixes = []string{"gen_ai.", "internal."}
+log.AddEventHook(s)
+```
+
 ## Compatibility
 
 The field names match the OTel GenAI semconv as of the latest stable.
@@ -128,8 +178,5 @@ emitted via this package directly.
 
 - `genai.Step` for agent multi-step trajectories — deferred until the
   OTel agent semconv stabilises
-- Adaptive sampling helper that always-keeps `error` and `gen_ai.*`
-  fields — needs `bolt.EventHook` (shipped) plus a small policy
-  helper here
 - Tighter typing for `FinishReason` (currently a `string`; semconv
   defines a small enum)

--- a/genai/hooks.go
+++ b/genai/hooks.go
@@ -1,0 +1,141 @@
+// EventHook helpers for AI workloads.
+//
+// The bolt core ships a generic [bolt.EventHook] surface (see
+// hook_v2_test.go in the parent module). This file provides two
+// pre-built hooks for the common GenAI use cases the multi-expert
+// review highlighted as "the two things that genuinely belong at the
+// logger layer":
+//
+//   1. RedactKeys — drop events whose payload contains any of a
+//      caller-supplied set of sensitive keys. The default deny list
+//      covers prompt / completion / messages / api_key / token; pass a
+//      custom list for project-specific concerns.
+//
+//   2. AdaptiveSample — sample low-importance events at a caller-set
+//      rate, but always keep events with sticky keys (default:
+//      `gen_ai.*` namespace and any error-level event). This makes
+//      token-stream debug logs cheap without losing GenAI breadcrumbs.
+//
+// Both hooks compose freely with Logger.AddHook(bolt.NewSampleHook(N))
+// for the simple uniform case. Compose by AddEventHook order: hooks
+// run sequentially, first false suppresses.
+package genai
+
+import (
+	"strings"
+	"sync/atomic"
+
+	"github.com/felixgeelhaar/bolt"
+)
+
+// DefaultDenyKeys is the default sensitive-key list used by
+// [NewRedactHook] when no override is provided. Matches the most
+// common GenAI fields that should not be logged verbatim.
+var DefaultDenyKeys = []string{
+	"prompt",
+	"completion",
+	"messages",
+	"input",
+	"output",
+	"api_key",
+	"token",
+	"authorization",
+}
+
+// RedactHook suppresses events whose buffer contains any field whose
+// key matches a configured deny entry. Match is case-sensitive exact;
+// callers wanting prefix or regex matching should write a custom hook
+// against [bolt.EventHook] directly.
+//
+// RedactHook does NOT redact in place — bolt's EventHook contract is
+// read-only. Suppression is the correct primitive for sensitive
+// content; if a redacted variant should still ship, log it explicitly
+// before the event reaches the hook.
+type RedactHook struct {
+	deny map[string]struct{}
+}
+
+// NewRedactHook returns a RedactHook that suppresses any event with
+// at least one field key in keys. If keys is empty, [DefaultDenyKeys]
+// is used.
+func NewRedactHook(keys ...string) *RedactHook {
+	if len(keys) == 0 {
+		keys = DefaultDenyKeys
+	}
+	deny := make(map[string]struct{}, len(keys))
+	for _, k := range keys {
+		deny[k] = struct{}{}
+	}
+	return &RedactHook{deny: deny}
+}
+
+// Run implements [bolt.EventHook].
+func (h *RedactHook) Run(e *bolt.Event, _ string) bool {
+	allow := true
+	e.WalkFields(func(key, _ []byte) bool {
+		if _, hit := h.deny[string(key)]; hit {
+			allow = false
+			return false // stop walking
+		}
+		return true
+	})
+	return allow
+}
+
+// AdaptiveSampler keeps 1 of every N low-importance events but always
+// keeps events whose level matches AlwaysKeepLevel or whose buffer
+// contains at least one field with a key matching AlwaysKeepPrefixes.
+//
+// Default behaviour ("always keep gen_ai.* and ERROR or higher") is a
+// good fit for GenAI workloads where token-stream debug logs swamp
+// the structured GenAI breadcrumbs that downstream tools care about.
+type AdaptiveSampler struct {
+	N                  uint32
+	AlwaysKeepLevel    bolt.Level
+	AlwaysKeepPrefixes []string
+
+	counter uint32
+}
+
+// NewAdaptiveSampler returns an AdaptiveSampler keeping 1 of every n
+// events whose level is below ERROR and whose fields don't match the
+// `gen_ai.` prefix. Pass n == 0 or 1 for "keep everything".
+func NewAdaptiveSampler(n uint32) *AdaptiveSampler {
+	return &AdaptiveSampler{
+		N:                  n,
+		AlwaysKeepLevel:    bolt.LevelError,
+		AlwaysKeepPrefixes: []string{"gen_ai."},
+	}
+}
+
+// Run implements [bolt.EventHook].
+func (s *AdaptiveSampler) Run(e *bolt.Event, _ string) bool {
+	// Always-keep level wins immediately.
+	if e.Level() >= s.AlwaysKeepLevel {
+		return true
+	}
+	// Always-keep prefix scan. Walk fields once; if any key matches,
+	// keep the event regardless of the sample counter.
+	keep := false
+	if len(s.AlwaysKeepPrefixes) > 0 {
+		e.WalkFields(func(key, _ []byte) bool {
+			k := string(key)
+			for _, p := range s.AlwaysKeepPrefixes {
+				if strings.HasPrefix(k, p) {
+					keep = true
+					return false
+				}
+			}
+			return true
+		})
+		if keep {
+			return true
+		}
+	}
+	// Standard 1-in-N sampling.
+	if s.N <= 1 {
+		return true
+	}
+	c := atomic.AddUint32(&s.counter, 1)
+	return c%s.N == 0
+}

--- a/genai/hooks_test.go
+++ b/genai/hooks_test.go
@@ -1,0 +1,155 @@
+package genai_test
+
+import (
+	"bytes"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/felixgeelhaar/bolt"
+	"github.com/felixgeelhaar/bolt/genai"
+)
+
+func TestRedactHook_DefaultDenyList(t *testing.T) {
+	var buf bytes.Buffer
+	logger := bolt.New(bolt.NewJSONHandler(&buf)).
+		AddEventHook(genai.NewRedactHook())
+
+	logger.Info().Str("user", "alice").Msg("login ok")
+	if !strings.Contains(buf.String(), `"user":"alice"`) {
+		t.Errorf("non-sensitive event suppressed: %q", buf.String())
+	}
+
+	for _, key := range []string{"prompt", "completion", "messages", "input", "output", "api_key", "token", "authorization"} {
+		buf.Reset()
+		logger.Info().Str(key, "secret-content").Msg("ignored")
+		if buf.Len() != 0 {
+			t.Errorf("event with sensitive key %q should have been suppressed, got %q", key, buf.String())
+		}
+	}
+}
+
+func TestRedactHook_CustomDenyList(t *testing.T) {
+	var buf bytes.Buffer
+	logger := bolt.New(bolt.NewJSONHandler(&buf)).
+		AddEventHook(genai.NewRedactHook("internal_secret", "session_id"))
+
+	buf.Reset()
+	// Default deny list keys are NOT suppressed when custom list passed.
+	logger.Info().Str("prompt", "hello").Msg("ok")
+	if !strings.Contains(buf.String(), `"prompt":"hello"`) {
+		t.Errorf("custom deny list should not suppress 'prompt'; got %q", buf.String())
+	}
+
+	buf.Reset()
+	logger.Info().Str("internal_secret", "x").Msg("blocked")
+	if buf.Len() != 0 {
+		t.Errorf("custom deny key should suppress; got %q", buf.String())
+	}
+}
+
+func TestAdaptiveSampler_AlwaysKeepGenAIFields(t *testing.T) {
+	var buf bytes.Buffer
+	logger := bolt.New(bolt.NewJSONHandler(&buf)).
+		AddEventHook(genai.NewAdaptiveSampler(1000))
+
+	// 5 debug events with gen_ai.* — must all pass.
+	for i := 0; i < 5; i++ {
+		buf.Reset()
+		logger.Debug().Str("gen_ai.system", "openai").Msg("trace")
+		if buf.Len() == 0 {
+			t.Errorf("iter %d: gen_ai-tagged debug should always pass, got suppressed", i)
+		}
+	}
+}
+
+func TestAdaptiveSampler_AlwaysKeepErrorLevel(t *testing.T) {
+	var buf bytes.Buffer
+	logger := bolt.New(bolt.NewJSONHandler(&buf)).
+		AddEventHook(genai.NewAdaptiveSampler(1000))
+
+	for i := 0; i < 5; i++ {
+		buf.Reset()
+		logger.Error().Str("user", "alice").Msg("boom")
+		if buf.Len() == 0 {
+			t.Errorf("iter %d: error-level event always-kept, got suppressed", i)
+		}
+	}
+}
+
+func TestAdaptiveSampler_LowImportanceSampled(t *testing.T) {
+	var buf bytes.Buffer
+	logger := bolt.New(bolt.NewJSONHandler(&buf)).
+		AddEventHook(genai.NewAdaptiveSampler(10))
+
+	const n = 1000
+	emitted := 0
+	for i := 0; i < n; i++ {
+		buf.Reset()
+		logger.Debug().Str("user", "alice").Msg("noise")
+		if buf.Len() != 0 {
+			emitted++
+		}
+	}
+	// Counter wraps at every 10th event, so we expect ~100 to pass.
+	if emitted < 70 || emitted > 130 {
+		t.Errorf("AdaptiveSampler emitted %d/%d (expected ~100)", emitted, n)
+	}
+}
+
+func TestAdaptiveSampler_NoSamplingWhenN0Or1(t *testing.T) {
+	for _, n := range []uint32{0, 1} {
+		var buf bytes.Buffer
+		hook := genai.NewAdaptiveSampler(n)
+		logger := bolt.New(bolt.NewJSONHandler(&buf)).AddEventHook(hook)
+
+		emitted := 0
+		for i := 0; i < 50; i++ {
+			buf.Reset()
+			logger.Debug().Str("user", "x").Msg("ok")
+			if buf.Len() != 0 {
+				emitted++
+			}
+		}
+		if emitted != 50 {
+			t.Errorf("N=%d should keep everything; got %d/50", n, emitted)
+		}
+	}
+}
+
+func TestAdaptiveSampler_CounterIsAtomic(t *testing.T) {
+	hook := genai.NewAdaptiveSampler(7)
+	var buf bytes.Buffer
+	logger := bolt.New(bolt.NewJSONHandler(&buf)).AddEventHook(hook)
+
+	const goroutines = 16
+	const perGoroutine = 1000
+	done := make(chan struct{})
+	var emitted int64
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			defer func() { done <- struct{}{} }()
+			local := bytes.NewBuffer(nil)
+			ll := bolt.New(bolt.NewJSONHandler(local)).AddEventHook(hook)
+			for i := 0; i < perGoroutine; i++ {
+				local.Reset()
+				ll.Debug().Str("user", "x").Msg("ok")
+				if local.Len() != 0 {
+					atomic.AddInt64(&emitted, 1)
+				}
+			}
+		}()
+	}
+	for g := 0; g < goroutines; g++ {
+		<-done
+	}
+	_ = logger // silence unused; the original logger is the regression check that AddEventHook with shared *AdaptiveSampler still works.
+
+	total := goroutines * perGoroutine
+	want := int64(total / 7)
+	got := atomic.LoadInt64(&emitted)
+	// Allow ±15% drift across 16 goroutines.
+	if got < want*85/100 || got > want*115/100 {
+		t.Errorf("concurrent sampler emitted %d/%d (expected ~%d, ±15%%)", got, total, want)
+	}
+}


### PR DESCRIPTION
## Summary

P3 batch — closes the `genai-redaction-and-sampling` roadmap item. Two pre-built `bolt.EventHook` implementations for the AI-workload concerns identified as the only two items that genuinely belong at the logger layer (everything else stays out of bolt by design).

## What's in this PR

- **`genai/hooks.go`** — `RedactHook` (deny-list suppression) + `AdaptiveSampler` (1-in-N with always-keep prefixes/levels)
- **`genai/hooks_test.go`** — 6 tests: default + custom deny lists, gen_ai.* always-keep, ERROR-level always-keep, low-importance sampling rate, N=0/1 = keep-everything, concurrent counter atomicity
- **`genai/README.md`** — new "Pre-built EventHooks" section with examples
- **`ROADMAP.md`** — bolt/genai item marked ✅

## Why

AI review:

> The two things that genuinely belong at the logger layer:
>   - Hook richness (a real bug today — you can't write a redaction hook without it)  
>   - Field-aware sampling (volume problem only the producer can solve cheaply)

Hook v2 (#59) shipped the surface; this PR ships the two reference implementations.

## Quick start

```go
import "github.com/felixgeelhaar/bolt/genai"

log := bolt.New(bolt.NewJSONHandler(os.Stdout)).
    AddEventHook(genai.NewRedactHook()).         // drop password/token/prompt/...
    AddEventHook(genai.NewAdaptiveSampler(100))  // keep error + gen_ai.*; sample rest 1/100
```

## Test plan

- [x] `cd genai && go test -count=1 ./...` — all 6 new tests + existing 7 pass
- [ ] Wait for full CI (parent module unaffected)