### PR TITLE
web+ci: modern redesign + coverctl/nox grade badges

### DIFF
--- a/.coverctl.yaml
+++ b/.coverctl.yaml
@@ -1,16 +1,20 @@
 version: 1
+# Coverage policy for the bolt root module. The bolt/genai sub-module
+# has its own go.mod and is measured separately by its own CI; if you
+# want a combined report locally, run coverctl against the genai dir
+# with that module's own .coverctl.yaml.
+#
+# Examples are standalone apps under their own go.mod files and are
+# excluded from coverage gates by virtue of not being on the import
+# path of the root module.
 policy:
   default:
     min: 70
   domains:
     - name: core
       match:
-        - github.com/felixgeelhaar/bolt/v3
-      min: 70
-    - name: examples
-      match:
-        - github.com/felixgeelhaar/bolt/v3/examples/...
-      min: 0  # Examples are standalone apps, not tested
+        - github.com/felixgeelhaar/bolt
+      min: 80
 history:
   enabled: true
   file: .coverctl-history.json

--- a/.github/nox-badge.svg
+++ b/.github/nox-badge.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="47" height="20" role="img" aria-label="nox: F">
+  <title>nox: F</title>
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <clipPath id="r">
+    <rect width="47" height="20" rx="3" fill="#fff"/>
+  </clipPath>
+  <g clip-path="url(#r)">
+    <rect width="29" height="20" fill="#555"/>
+    <rect x="29" width="18" height="20" fill="#b60205"/>
+    <rect width="47" height="20" fill="url(#s)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
+    <text aria-hidden="true" x="145" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">nox</text>
+    <text x="145" y="140" transform="scale(.1)">nox</text>
+    <text aria-hidden="true" x="380" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">F</text>
+    <text x="380" y="140" transform="scale(.1)">F</text>
+  </g>
+</svg>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,13 +43,34 @@ jobs:
     - name: Run tests with count flag (detect flaky tests)
       run: go test -v -short -count=5 ./...
 
-    - name: Upload coverage to Codecov
+    # Coverage gate + badge refresh via coverctl (replaces Codecov).
+    # The .coverctl.yaml policy enforces minimums per domain; the
+    # generated SVG lives in assets/ and is referenced from README +
+    # the GH Pages landing.
+    - name: Install coverctl
       if: matrix.go-version == '1.25'
-      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v5
-      with:
-        file: ./coverage.out
-        flags: unittests
-        name: codecov-umbrella
+      run: go install github.com/felixgeelhaar/coverctl/cmd/coverctl@latest
+      env:
+        GOTOOLCHAIN: auto
+
+    - name: Coverctl gate
+      if: matrix.go-version == '1.25'
+      run: |
+        mkdir -p .cover
+        cp coverage.out .cover/coverage.out
+        coverctl check --fromProfile -p .cover/coverage.out
+
+    - name: Refresh coverage badge (push to main only)
+      if: matrix.go-version == '1.25' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      run: |
+        coverctl badge -p .cover/coverage.out -o assets/badge-coverage.svg --label coverage
+        if ! git diff --quiet assets/badge-coverage.svg; then
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git add assets/badge-coverage.svg
+          git commit -m "ci(badge): refresh coverage badge [skip ci]"
+          git push origin HEAD:main || echo "::warning::badge push blocked by branch protection"
+        fi
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,8 +1,20 @@
 name: Deploy to GitHub Pages
 
+# Publishes the static landing page (index.html + assets/) from the
+# repo root directly to GitHub Pages. Previous version of this
+# workflow checked out a `gh-pages` orphan branch, copied docs/* to
+# the root, and `sed`d benchmark numbers into HTML structures that no
+# longer exist. The 2026 redesign uses a static bench table — numbers
+# are updated by the maintainer with the rest of the page when they
+# care to refresh; the website does not auto-mutate from CI.
+
 on:
   push:
-    branches: [ main ]
+    branches: [main]
+    paths:
+      - 'index.html'
+      - 'assets/**'
+      - '.github/workflows/deploy-pages.yml'
   workflow_dispatch:
 
 permissions:
@@ -11,118 +23,36 @@ permissions:
   id-token: write
 
 concurrency:
-  group: "pages"
+  group: pages
   cancel-in-progress: false
 
 jobs:
-  build-and-deploy:
+  deploy:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    
     steps:
-    - name: Checkout
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        fetch-depth: 0
-    
-    - name: Setup Pages
-      uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
-    
-    - name: Setup Go
-      uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
-      with:
-        go-version: '1.25'
-    
-    - name: Run benchmarks
-      run: |
-        echo "Running latest benchmarks..."
-        go test -bench=. -benchmem -count=3 > benchmark_results.txt 2>&1 || true
-        echo "Latest benchmark results:"
-        cat benchmark_results.txt
-    
-    - name: Checkout gh-pages branch  
-      run: |
-        git fetch origin gh-pages:gh-pages || echo "gh-pages branch doesn't exist yet"
-        git checkout gh-pages || git checkout --orphan gh-pages
-        
-        # Copy website files from main branch
-        # Copy website files from main branch docs folder
-        git checkout main -- docs/ 2>/dev/null || echo "Copying website files"
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-        # Move docs contents to root for GitHub Pages
-        if [ -d "docs" ]; then
-          cp -r docs/* .
-          rm -rf docs/
-        fi
-        
-        # Copy benchmark results
-        cp ../benchmark_results.txt . 2>/dev/null || echo "No benchmark results to copy"
-    
-    - name: Update website with benchmark data
-      run: |
-        echo "Processing benchmark data..."
-        if [ -f "benchmark_results.txt" ]; then
-          # Extract the ns/op value for Bolt benchmarks
-          BOLT_NSOP=$(grep -E "BenchmarkZeroAllocation|BenchmarkBolt" benchmark_results.txt | head -1 | awk '{print $3}' | tr -d 'ns/op')
-          
-          if [ -n "$BOLT_NSOP" ]; then
-            echo "Found Bolt benchmark: ${BOLT_NSOP}ns/op"
-            
-            # Calculate improvement percentage (baseline: 175.4 for Zerolog)
-            IMPROVEMENT=$(awk "BEGIN {printf \"%.0f\", (175.4 - $BOLT_NSOP) / 175.4 * 100}")
-            
-            # Create benchmark data JSON
-            mkdir -p assets/data
-            cat > assets/data/latest-benchmarks.json <<EOF
-        {
-          "timestamp": "$(date -u +'%Y-%m-%dT%H:%M:%SZ')",
-          "bolt_ns_per_op": $BOLT_NSOP,
-          "zerolog_ns_per_op": 175.4,
-          "improvement_percent": $IMPROVEMENT,
-          "source": "ci-automated",
-          "commit": "${GITHUB_SHA}"
-        }
-        EOF
-            echo "Created benchmark data with real values"
-            
-            # Update index.html with new benchmark values
-            if [ -f "index.html" ]; then
-              # Update hero badge
-              sed -i "s/⚡ [0-9.]*ns\/op • 0 allocations • [0-9]*% faster than Zerolog/⚡ ${BOLT_NSOP}ns\/op • 0 allocations • ${IMPROVEMENT}% faster than Zerolog/g" index.html
-              
-              # Update benchmark table (find Bolt row and update the ns/op value)
-              sed -i "/<td><strong>Bolt<\/strong><\/td>/,/<\/tr>/{s/<td><strong>[0-9.]*<\/strong><\/td>/<td><strong>${BOLT_NSOP}<\/strong><\/td>/}" index.html
-              
-              # Update performance advantage
-              sed -i "s/<td class=\"advantage\">[0-9]*% faster than Zerolog<\/td>/<td class=\"advantage\">${IMPROVEMENT}% faster than Zerolog<\/td>/g" index.html
-              
-              echo "Updated index.html with latest benchmarks"
-            fi
-            
-            # Update script.js with new values
-            if [ -f "assets/script.js" ]; then
-              # Update the default bolt value in initPerformanceChart
-              sed -i "s/initPerformanceChart(boltValue = [0-9.]*)/initPerformanceChart(boltValue = ${BOLT_NSOP})/g" assets/script.js
-              
-              # Update the data array
-              sed -i "s/{ label: 'Bolt', value: [0-9.]*, class: 'bolt' }/{ label: 'Bolt', value: ${BOLT_NSOP}, class: 'bolt' }/g" assets/script.js
-              
-              echo "Updated script.js with latest benchmarks"
-            fi
-          else
-            echo "No Bolt benchmark found in results"
-          fi
-        else
-          echo "No benchmark results file found"
-        fi
-    
-    - name: Upload artifact
-      uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
-      with:
-        path: '.'
-    
-    - name: Deploy to GitHub Pages
-      id: deployment
-      uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+      - name: Setup Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
+      - name: Stage site
+        run: |
+          # Only ship the landing page assets — no Go source, no docs/,
+          # no oss-fuzz/, no .nox/. The Pages site is the marketing
+          # surface; technical docs live on github.com via the
+          # repository browser and pkg.go.dev.
+          mkdir -p _site
+          cp index.html _site/
+          cp -r assets _site/
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
+        with:
+          path: _site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -86,3 +86,17 @@ jobs:
           name: nox-findings
           path: findings.json
           retention-days: 90
+
+      - name: Refresh nox grade badge (push to main)
+        if: github.event_name == 'push' && hashFiles('findings.json') != ''
+        run: |
+          nox badge -input findings.json -output assets/badge-nox.svg
+          if ! git diff --quiet assets/badge-nox.svg; then
+            git config user.name 'github-actions[bot]'
+            git config user.email 'github-actions[bot]@users.noreply.github.com'
+            git add assets/badge-nox.svg
+            git commit -m "ci(badge): refresh nox grade badge [skip ci]"
+            # Push directly only if branch protection allows admin/bot pushes;
+            # otherwise this errors and the artifact is the source of truth.
+            git push origin HEAD:main || echo "::warning::badge push blocked by branch protection — see findings artifact"
+          fi

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
   Zero-allocation `slog.Handler` for Go with first-class OpenTelemetry.
 
   [![Build](https://github.com/felixgeelhaar/bolt/actions/workflows/ci.yml/badge.svg)](https://github.com/felixgeelhaar/bolt/actions/workflows/ci.yml)
-  [![Nox Security](https://github.com/felixgeelhaar/bolt/actions/workflows/nox.yml/badge.svg)](https://github.com/felixgeelhaar/bolt/actions/workflows/nox.yml)
-  [![codecov](https://codecov.io/gh/felixgeelhaar/bolt/branch/main/graph/badge.svg)](https://codecov.io/gh/felixgeelhaar/bolt)
+  [![Nox security grade](https://raw.githubusercontent.com/felixgeelhaar/bolt/main/assets/badge-nox.svg)](https://github.com/felixgeelhaar/bolt/actions/workflows/nox.yml)
+  [![Coverage](https://raw.githubusercontent.com/felixgeelhaar/bolt/main/assets/badge-coverage.svg)](https://github.com/felixgeelhaar/bolt/actions/workflows/ci.yml)
   [![Go Reference](https://pkg.go.dev/badge/github.com/felixgeelhaar/bolt.svg)](https://pkg.go.dev/github.com/felixgeelhaar/bolt)
   [![Go Report Card](https://goreportcard.com/badge/github.com/felixgeelhaar/bolt)](https://goreportcard.com/report/github.com/felixgeelhaar/bolt)
   [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/assets/badge-coverage.svg
+++ b/assets/badge-coverage.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="111" height="20" role="img" aria-label="coverage: 85.4%">
+  <title>coverage: 85.4%</title>
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <clipPath id="r">
+    <rect width="111" height="20" rx="3" fill="#fff"/>
+  </clipPath>
+  <g clip-path="url(#r)">
+    <rect width="66" height="20" fill="#555"/>
+    <rect x="66" width="45" height="20" fill="#97ca00"/>
+    <rect width="111" height="20" fill="url(#s)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
+    <text aria-hidden="true" x="330" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="560">coverage</text>
+    <text x="330" y="140" transform="scale(.1)" fill="#fff" textLength="560">coverage</text>
+    <text aria-hidden="true" x="880" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="350">85.4%</text>
+    <text x="880" y="140" transform="scale(.1)" fill="#fff" textLength="350">85.4%</text>
+  </g>
+</svg>

--- a/assets/badge-nox.svg
+++ b/assets/badge-nox.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="47" height="20" role="img" aria-label="nox: F">
+  <title>nox: F</title>
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <clipPath id="r">
+    <rect width="47" height="20" rx="3" fill="#fff"/>
+  </clipPath>
+  <g clip-path="url(#r)">
+    <rect width="29" height="20" fill="#555"/>
+    <rect x="29" width="18" height="20" fill="#b60205"/>
+    <rect width="47" height="20" fill="url(#s)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
+    <text aria-hidden="true" x="145" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">nox</text>
+    <text x="145" y="140" transform="scale(.1)">nox</text>
+    <text aria-hidden="true" x="380" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">F</text>
+    <text x="380" y="140" transform="scale(.1)">F</text>
+  </g>
+</svg>

--- a/assets/script.js
+++ b/assets/script.js
@@ -1,419 +1,82 @@
-// Bolt Landing Page Interactive Features
-// Performance-focused, zero-dependency JavaScript
+// Bolt landing page — minimal vanilla JS.
+// Two responsibilities only:
+//   1. Theme toggle (system → user override → localStorage persistence)
+//   2. Copy-to-clipboard buttons
+//
+// Anything else (Chart.js, fake "trend data", PerformanceObserver,
+// simulated loaders) was removed in the 2026 redesign. The previous
+// script set up a perf chart against fabricated values which leaked
+// trust as soon as anyone read the source. The bench table in
+// index.html is now the source of truth.
 
-class BoltLandingPage {
-    constructor() {
-        this.charts = {};
-        this.benchmarkData = [];
-        this.init();
+(() => {
+  'use strict';
+
+  // ---- Theme ---------------------------------------------------------------
+  const THEME_KEY = 'bolt-theme';
+  const root = document.documentElement;
+
+  function applyStoredTheme() {
+    try {
+      const stored = localStorage.getItem(THEME_KEY);
+      if (stored === 'dark' || stored === 'light') {
+        root.setAttribute('data-theme', stored);
+      }
+    } catch (_) {
+      // localStorage may be blocked (private mode); no-op.
+    }
+  }
+
+  function currentResolvedTheme() {
+    const explicit = root.getAttribute('data-theme');
+    if (explicit) return explicit;
+    return window.matchMedia('(prefers-color-scheme: dark)').matches
+      ? 'dark'
+      : 'light';
+  }
+
+  function toggleTheme() {
+    const next = currentResolvedTheme() === 'dark' ? 'light' : 'dark';
+    root.setAttribute('data-theme', next);
+    try {
+      localStorage.setItem(THEME_KEY, next);
+    } catch (_) {
+      // ignore
+    }
+  }
+
+  applyStoredTheme();
+  document.addEventListener('DOMContentLoaded', () => {
+    const btn = document.querySelector('.theme-toggle');
+    if (btn) {
+      btn.addEventListener('click', toggleTheme);
     }
 
-    init() {
-        this.initializeCharts();
-        this.setupCopyButtons();
-        this.setupSmoothScrolling();
-        this.loadBenchmarkData();
-        this.setupNavbarScroll();
-    }
-
-    // Initialize Chart.js visualizations
-    initializeCharts() {
-        this.initPerformanceChart();
-        this.initBenchmarkTrendChart();
-    }
-
-    initPerformanceChart() {
-        const ctx = document.getElementById('performanceChart');
-        if (!ctx) return;
-
-        this.charts.performance = new Chart(ctx, {
-            type: 'bar',
-            data: {
-                labels: ['Bolt', 'Zerolog', 'Zap', 'Logrus'],
-                datasets: [{
-                    label: 'Performance (ns/op)',
-                    data: [127.1, 175.4, 189.7, 2847],
-                    backgroundColor: [
-                        '#2563EB', // Bolt - primary blue
-                        '#6B7280', // Others - gray
-                        '#6B7280',
-                        '#6B7280'
-                    ],
-                    borderColor: [
-                        '#1D4ED8',
-                        '#4B5563',
-                        '#4B5563',
-                        '#4B5563'
-                    ],
-                    borderWidth: 2,
-                    borderRadius: 8,
-                    borderSkipped: false,
-                }]
-            },
-            options: {
-                responsive: true,
-                maintainAspectRatio: false,
-                plugins: {
-                    legend: {
-                        display: false
-                    },
-                    tooltip: {
-                        backgroundColor: '#1F2937',
-                        titleColor: '#F9FAFB',
-                        bodyColor: '#F9FAFB',
-                        borderColor: '#374151',
-                        borderWidth: 1,
-                        callbacks: {
-                            label: function(context) {
-                                const value = context.parsed.y;
-                                const improvement = value < 127.1 ? '' : 
-                                    ` (${Math.round((value - 127.1) / 127.1 * 100)}% slower)`;
-                                return `${context.label}: ${value}ns/op${improvement}`;
-                            }
-                        }
-                    }
-                },
-                scales: {
-                    x: {
-                        grid: {
-                            display: false
-                        },
-                        ticks: {
-                            font: {
-                                family: 'Inter',
-                                size: 12,
-                                weight: 500
-                            }
-                        }
-                    },
-                    y: {
-                        beginAtZero: true,
-                        type: 'logarithmic',
-                        grid: {
-                            color: '#E5E7EB'
-                        },
-                        ticks: {
-                            font: {
-                                family: 'Inter',
-                                size: 12
-                            },
-                            callback: function(value) {
-                                return value + 'ns';
-                            }
-                        }
-                    }
-                },
-                animation: {
-                    duration: 2000,
-                    easing: 'easeOutQuart'
-                }
-            }
-        });
-    }
-
-    initBenchmarkTrendChart() {
-        const ctx = document.getElementById('benchmarkChart');
-        if (!ctx) return;
-
-        // Placeholder data - will be replaced with real data from GitHub Actions
-        const mockData = this.generateMockBenchmarkData();
-
-        this.charts.benchmarkTrend = new Chart(ctx, {
-            type: 'line',
-            data: {
-                labels: mockData.dates,
-                datasets: [
-                    {
-                        label: 'Bolt (Enabled)',
-                        data: mockData.boltEnabled,
-                        borderColor: '#2563EB',
-                        backgroundColor: 'rgba(37, 99, 235, 0.1)',
-                        fill: true,
-                        tension: 0.4,
-                        pointRadius: 4,
-                        pointHoverRadius: 6,
-                        pointBackgroundColor: '#2563EB',
-                        pointBorderColor: '#ffffff',
-                        pointBorderWidth: 2
-                    },
-                    {
-                        label: 'Zerolog (Enabled)',
-                        data: mockData.zerologEnabled,
-                        borderColor: '#6B7280',
-                        backgroundColor: 'rgba(107, 114, 128, 0.1)',
-                        fill: false,
-                        tension: 0.4,
-                        pointRadius: 3,
-                        pointHoverRadius: 5,
-                        pointBackgroundColor: '#6B7280',
-                        pointBorderColor: '#ffffff',
-                        pointBorderWidth: 2
-                    }
-                ]
-            },
-            options: {
-                responsive: true,
-                maintainAspectRatio: false,
-                plugins: {
-                    legend: {
-                        position: 'top',
-                        labels: {
-                            font: {
-                                family: 'Inter',
-                                size: 12,
-                                weight: 500
-                            }
-                        }
-                    },
-                    tooltip: {
-                        backgroundColor: '#1F2937',
-                        titleColor: '#F9FAFB',
-                        bodyColor: '#F9FAFB',
-                        borderColor: '#374151',
-                        borderWidth: 1,
-                        callbacks: {
-                            label: function(context) {
-                                return `${context.dataset.label}: ${context.parsed.y}ns/op`;
-                            }
-                        }
-                    }
-                },
-                scales: {
-                    x: {
-                        type: 'time',
-                        time: {
-                            unit: 'day',
-                            displayFormats: {
-                                day: 'MMM dd'
-                            }
-                        },
-                        grid: {
-                            display: false
-                        },
-                        ticks: {
-                            font: {
-                                family: 'Inter',
-                                size: 12
-                            }
-                        }
-                    },
-                    y: {
-                        beginAtZero: true,
-                        grid: {
-                            color: '#E5E7EB'
-                        },
-                        ticks: {
-                            font: {
-                                family: 'Inter',
-                                size: 12
-                            },
-                            callback: function(value) {
-                                return value + 'ns';
-                            }
-                        }
-                    }
-                },
-                animation: {
-                    duration: 2000,
-                    easing: 'easeOutQuart'
-                }
-            }
-        });
-    }
-
-    generateMockBenchmarkData() {
-        const dates = [];
-        const boltEnabled = [];
-        const zerologEnabled = [];
-        const startDate = new Date();
-        startDate.setDate(startDate.getDate() - 30);
-
-        for (let i = 0; i < 30; i++) {
-            const date = new Date(startDate);
-            date.setDate(startDate.getDate() + i);
-            dates.push(date);
-            
-            // Simulate improving performance over time for Bolt
-            const baseBolt = 140 - (i * 0.4);
-            boltEnabled.push(baseBolt + (Math.random() - 0.5) * 5);
-            
-            // Zerolog remains relatively stable
-            zerologEnabled.push(175 + (Math.random() - 0.5) * 8);
-        }
-
-        return { dates, boltEnabled, zerologEnabled };
-    }
-
-    // Copy to clipboard functionality
-    setupCopyButtons() {
-        document.querySelectorAll('.copy-btn').forEach(btn => {
-            btn.addEventListener('click', (e) => {
-                e.preventDefault();
-                const textToCopy = btn.getAttribute('data-copy');
-                
-                // Modern clipboard API with fallback
-                if (navigator.clipboard && window.isSecureContext) {
-                    navigator.clipboard.writeText(textToCopy).then(() => {
-                        this.showCopyFeedback(btn);
-                    });
-                } else {
-                    // Fallback for older browsers
-                    this.fallbackCopyToClipboard(textToCopy);
-                    this.showCopyFeedback(btn);
-                }
-            });
-        });
-    }
-
-    fallbackCopyToClipboard(text) {
-        const textArea = document.createElement('textarea');
-        textArea.value = text;
-        textArea.style.position = 'fixed';
-        textArea.style.left = '-999999px';
-        textArea.style.top = '-999999px';
-        document.body.appendChild(textArea);
-        textArea.focus();
-        textArea.select();
-        document.execCommand('copy');
-        textArea.remove();
-    }
-
-    showCopyFeedback(btn) {
-        const originalHTML = btn.innerHTML;
-        btn.innerHTML = '<svg viewBox="0 0 24 24"><path d="M20.285 2l-11.285 11.567-5.286-5.011-3.714 3.716 9 8.728 15-15.285z"/></svg>';
-        btn.style.color = '#10B981';
-        
-        setTimeout(() => {
-            btn.innerHTML = originalHTML;
-            btn.style.color = '';
-        }, 2000);
-    }
-
-    // Smooth scrolling for navigation
-    setupSmoothScrolling() {
-        document.querySelectorAll('a[href^="#"]').forEach(anchor => {
-            anchor.addEventListener('click', (e) => {
-                e.preventDefault();
-                const target = document.querySelector(anchor.getAttribute('href'));
-                if (target) {
-                    const offset = 80; // Account for fixed navbar
-                    const elementPosition = target.offsetTop;
-                    const offsetPosition = elementPosition - offset;
-
-                    window.scrollTo({
-                        top: offsetPosition,
-                        behavior: 'smooth'
-                    });
-                }
-            });
-        });
-    }
-
-    // Navbar scroll effects
-    setupNavbarScroll() {
-        let lastScrollTop = 0;
-        const navbar = document.querySelector('.navbar');
-        
-        window.addEventListener('scroll', () => {
-            const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
-            
-            // Add shadow when scrolled
-            if (scrollTop > 10) {
-                navbar.style.boxShadow = '0 4px 6px -1px rgb(0 0 0 / 0.1)';
-            } else {
-                navbar.style.boxShadow = '';
-            }
-            
-            lastScrollTop = scrollTop;
-        });
-    }
-
-    // Load real benchmark data from GitHub Actions
-    async loadBenchmarkData() {
-        const loadingElement = document.getElementById('chartLoading');
-        
+    // ---- Copy buttons -----------------------------------------------------
+    document.querySelectorAll('.copy-btn[data-copy]').forEach((btn) => {
+      btn.addEventListener('click', async () => {
+        const id = btn.getAttribute('data-copy');
+        const node = document.getElementById(id);
+        if (!node) return;
+        const text = node.innerText.trim();
         try {
-            // This would fetch from GitHub Actions artifacts in a real implementation
-            // For now, we'll simulate loading and then hide the loading indicator
-            await this.simulateDataLoading();
-            
-            if (loadingElement) {
-                loadingElement.style.display = 'none';
-            }
-            
-            // Update footer stats with real data
-            this.updateFooterStats();
-            
-        } catch (error) {
-            console.warn('Failed to load benchmark data:', error);
-            if (loadingElement) {
-                loadingElement.innerHTML = '<p style="color: #6B7280;">Using cached benchmark data</p>';
-            }
+          await navigator.clipboard.writeText(text);
+          const orig = btn.textContent;
+          btn.textContent = 'Copied';
+          btn.classList.add('copied');
+          setTimeout(() => {
+            btn.textContent = orig;
+            btn.classList.remove('copied');
+          }, 1400);
+        } catch (_) {
+          // Clipboard API blocked. Fall back to selection.
+          const range = document.createRange();
+          range.selectNodeContents(node);
+          const sel = window.getSelection();
+          sel.removeAllRanges();
+          sel.addRange(range);
         }
-    }
-
-    async simulateDataLoading() {
-        // Simulate API call delay
-        return new Promise(resolve => {
-            setTimeout(resolve, 2000);
-        });
-    }
-
-    updateFooterStats() {
-        const statsElement = document.getElementById('footerStats');
-        if (!statsElement) return;
-
-        // In a real implementation, this would come from GitHub API
-        const stats = {
-            version: 'v1.0.0',
-            goVersion: 'Go 1.21+',
-            dependencies: '0 Dependencies',
-            lastUpdate: new Date().toLocaleDateString()
-        };
-
-        statsElement.innerHTML = `
-            <span class="stat">Latest: ${stats.version}</span>
-            <span class="stat">${stats.goVersion}</span>
-            <span class="stat">${stats.dependencies}</span>
-        `;
-    }
-
-    // Utility method for future GitHub Actions integration
-    async fetchBenchmarkData() {
-        // This would integrate with GitHub Actions workflow artifacts
-        // Example endpoint: https://api.github.com/repos/felixgeelhaar/bolt/actions/artifacts
-        const response = await fetch('/api/benchmarks');
-        return response.json();
-    }
-}
-
-// Performance monitoring
-const performanceObserver = new PerformanceObserver((list) => {
-    list.getEntries().forEach((entry) => {
-        if (entry.entryType === 'largest-contentful-paint') {
-            console.log('LCP:', entry.startTime);
-        }
+      });
     });
-});
-
-// Initialize when DOM is ready
-document.addEventListener('DOMContentLoaded', () => {
-    // Start performance monitoring
-    if (typeof PerformanceObserver !== 'undefined') {
-        performanceObserver.observe({ entryTypes: ['largest-contentful-paint'] });
-    }
-    
-    // Initialize landing page functionality
-    window.boltLanding = new BoltLandingPage();
-});
-
-// Handle window resize for charts
-window.addEventListener('resize', () => {
-    if (window.boltLanding && window.boltLanding.charts) {
-        Object.values(window.boltLanding.charts).forEach(chart => {
-            if (chart && typeof chart.resize === 'function') {
-                chart.resize();
-            }
-        });
-    }
-});
+  });
+})();

--- a/assets/style.css
+++ b/assets/style.css
@@ -342,6 +342,14 @@ pre code { background: transparent; padding: 0; border-radius: 0; font-size: 0.8
 }
 .cta-primary:hover { background: var(--accent-hover); color: var(--accent-fg); text-decoration: none; transform: translateY(-1px); }
 
+.badges-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--s-2);
+  margin-bottom: var(--s-3);
+}
+.badges-row img { display: block; height: 20px; }
+
 .trust-strip {
   list-style: none;
   display: flex;

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,755 +1,677 @@
-/* Reset and Base Styles */
-* {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-}
+/* Bolt landing — modern, dark-first, no-framework CSS.
+   Tokens are semantic (--bg, --fg, --accent, --code-bg) so dark
+   mode is one media query. Class names match index.html exactly. */
 
 :root {
-    /* Colors */
-    --primary-600: #2563EB;
-    --primary-700: #1D4ED8;
-    --primary-50: #EFF6FF;
-    --secondary-600: #DC2626;
-    --secondary-700: #B91C1C;
-    --gray-50: #F9FAFB;
-    --gray-100: #F3F4F6;
-    --gray-200: #E5E7EB;
-    --gray-300: #D1D5DB;
-    --gray-400: #9CA3AF;
-    --gray-500: #6B7280;
-    --gray-600: #4B5563;
-    --gray-700: #374151;
-    --gray-800: #1F2937;
-    --gray-900: #111827;
-    --green-500: #10B981;
-    --green-600: #059669;
-    --amber-500: #F59E0B;
-    --red-500: #EF4444;
-    
-    /* Typography */
-    --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
-    --font-mono: 'JetBrains Mono', 'SF Mono', 'Monaco', 'Cascadia Code', monospace;
-    
-    /* Spacing */
-    --space-1: 0.25rem;
-    --space-2: 0.5rem;
-    --space-3: 0.75rem;
-    --space-4: 1rem;
-    --space-6: 1.5rem;
-    --space-8: 2rem;
-    --space-12: 3rem;
-    --space-16: 4rem;
-    --space-20: 5rem;
-    --space-24: 6rem;
-    
-    /* Shadows */
-    --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-    --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
-    --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
-    --shadow-xl: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
-    
-    /* Border Radius */
-    --radius-sm: 0.375rem;
-    --radius-md: 0.5rem;
-    --radius-lg: 0.75rem;
-    --radius-xl: 1rem;
-    
-    /* Transitions */
-    --transition-fast: all 0.15s ease;
-    --transition-normal: all 0.3s ease;
+  color-scheme: dark light;
+
+  /* Type */
+  --font-sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI",
+               Roboto, "Helvetica Neue", Arial, sans-serif;
+  --font-mono: ui-monospace, "JetBrains Mono", "SF Mono", Menlo,
+               Consolas, "Liberation Mono", monospace;
+
+  /* Spacing scale */
+  --s-1: 0.25rem;
+  --s-2: 0.5rem;
+  --s-3: 0.75rem;
+  --s-4: 1rem;
+  --s-5: 1.5rem;
+  --s-6: 2rem;
+  --s-7: 3rem;
+  --s-8: 4rem;
+  --s-9: 6rem;
+
+  /* Radii */
+  --r-sm: 6px;
+  --r-md: 10px;
+  --r-lg: 14px;
+
+  /* Light theme (default if user has no preference) */
+  --bg:        #fafafa;
+  --bg-alt:    #f3f4f6;
+  --fg:        #0b0f19;
+  --fg-muted:  #4b5563;
+  --fg-faint:  #6b7280;
+  --border:    #e5e7eb;
+  --border-strong: #d1d5db;
+  --accent:    #2563eb;
+  --accent-hover: #1d4ed8;
+  --accent-fg: #ffffff;
+  --code-bg:   #f3f4f6;
+  --code-fg:   #111827;
+  --terminal-bg: #0b0f19;
+  --terminal-fg: #e5e7eb;
+  --tk-key:    #93c5fd;
+  --tk-str:    #86efac;
+  --tk-num:    #fcd34d;
+  --tk-kw:     #f472b6;
+  --tk-fn:     #38bdf8;
+  --tk-cm:     #94a3b8;
+  --tk-hl-bg:  rgba(252, 211, 77, 0.18);
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
+  --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.08);
 }
 
-html {
-    scroll-behavior: smooth;
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg:        #0b0f19;
+    --bg-alt:    #111827;
+    --fg:        #f3f4f6;
+    --fg-muted:  #cbd5e1;
+    --fg-faint:  #94a3b8;
+    --border:    #1f2937;
+    --border-strong: #334155;
+    --accent:    #60a5fa;
+    --accent-hover: #93c5fd;
+    --accent-fg: #0b0f19;
+    --code-bg:   #0f172a;
+    --code-fg:   #e2e8f0;
+    --terminal-bg: #050810;
+    --terminal-fg: #e5e7eb;
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+    --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.5);
+  }
+}
+
+/* Manual override via [data-theme]; persisted by script.js */
+:root[data-theme="dark"] {
+  --bg:        #0b0f19;
+  --bg-alt:    #111827;
+  --fg:        #f3f4f6;
+  --fg-muted:  #cbd5e1;
+  --fg-faint:  #94a3b8;
+  --border:    #1f2937;
+  --border-strong: #334155;
+  --accent:    #60a5fa;
+  --accent-hover: #93c5fd;
+  --accent-fg: #0b0f19;
+  --code-bg:   #0f172a;
+  --code-fg:   #e2e8f0;
+  --terminal-bg: #050810;
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+  --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.5);
+}
+
+:root[data-theme="light"] {
+  --bg:        #fafafa;
+  --bg-alt:    #f3f4f6;
+  --fg:        #0b0f19;
+  --fg-muted:  #4b5563;
+  --fg-faint:  #6b7280;
+  --border:    #e5e7eb;
+  --border-strong: #d1d5db;
+  --accent:    #2563eb;
+  --accent-hover: #1d4ed8;
+  --accent-fg: #ffffff;
+  --code-bg:   #f3f4f6;
+  --code-fg:   #111827;
+  --terminal-bg: #0b0f19;
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
+  --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.08);
+}
+
+/* Reset */
+*, *::before, *::after { box-sizing: border-box; }
+* { margin: 0; padding: 0; }
+html { scroll-behavior: smooth; }
+@media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior: auto; }
+  *, *::before, *::after { animation-duration: 0.01ms !important; transition-duration: 0.01ms !important; }
 }
 
 body {
-    font-family: var(--font-sans);
-    line-height: 1.6;
-    color: var(--gray-800);
-    background-color: white;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
+  font-family: var(--font-sans);
+  font-size: 16px;
+  line-height: 1.55;
+  color: var(--fg);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
 }
 
-/* Container */
+a { color: var(--accent); text-decoration: none; }
+a:hover { color: var(--accent-hover); text-decoration: underline; }
+a:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 2px; }
+
+code {
+  font-family: var(--font-mono);
+  font-size: 0.92em;
+  background: var(--code-bg);
+  color: var(--code-fg);
+  padding: 0.1em 0.35em;
+  border-radius: var(--r-sm);
+}
+pre code { background: transparent; padding: 0; border-radius: 0; font-size: 0.875rem; }
+
+/* Skip link */
+.skip {
+  position: absolute;
+  left: -9999px;
+  top: 0;
+  padding: var(--s-3) var(--s-4);
+  background: var(--accent);
+  color: var(--accent-fg);
+  font-weight: 600;
+  border-radius: 0 0 var(--r-sm) 0;
+  z-index: 100;
+}
+.skip:focus { left: 0; }
+
+/* Layout */
 .container {
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 0 var(--space-4);
+  width: 100%;
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0 var(--s-5);
 }
 
-/* Navigation */
+/* Navbar */
 .navbar {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    background: rgba(255, 255, 255, 0.9);
-    backdrop-filter: blur(12px);
-    border-bottom: 1px solid var(--gray-200);
-    z-index: 1000;
-    transition: var(--transition-normal);
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: color-mix(in srgb, var(--bg) 88%, transparent);
+  backdrop-filter: saturate(180%) blur(12px);
+  border-bottom: 1px solid var(--border);
 }
-
-.nav-container {
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 0 var(--space-4);
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    height: 4rem;
+.nav-row {
+  display: flex;
+  align-items: center;
+  gap: var(--s-5);
+  height: 60px;
 }
-
-.nav-logo {
-    height: 2rem;
-    width: auto;
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--s-2);
+  color: var(--fg);
+  font-weight: 700;
+  font-size: 1rem;
+  text-decoration: none;
 }
+.brand img { display: block; }
+.brand-text { letter-spacing: -0.01em; }
 
 .nav-links {
-    display: flex;
-    align-items: center;
-    gap: var(--space-8);
+  display: flex;
+  align-items: center;
+  gap: var(--s-5);
+  margin-left: auto;
+}
+.nav-links a {
+  color: var(--fg-muted);
+  font-size: 0.92rem;
+  font-weight: 500;
+  text-decoration: none;
+}
+.nav-links a:hover { color: var(--fg); }
+
+.github-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--s-2);
+  padding: 0.4rem 0.8rem;
+  background: var(--bg-alt);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--r-md);
+  color: var(--fg);
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-decoration: none;
+}
+.github-cta:hover { background: var(--bg); border-color: var(--accent); color: var(--fg); text-decoration: none; }
+
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  color: var(--fg-muted);
+  cursor: pointer;
+}
+.theme-toggle:hover { color: var(--fg); border-color: var(--border-strong); }
+.theme-icon-moon { display: none; }
+:root[data-theme="dark"] .theme-icon-sun { display: none; }
+:root[data-theme="dark"] .theme-icon-moon { display: block; }
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .theme-icon-sun { display: none; }
+  :root:not([data-theme="light"]) .theme-icon-moon { display: block; }
 }
 
-.nav-link {
-    text-decoration: none;
-    color: var(--gray-600);
-    font-weight: 500;
-    font-size: 0.875rem;
-    transition: var(--transition-fast);
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
+@media (max-width: 720px) {
+  .nav-links { display: none; }
 }
 
-.nav-link:hover {
-    color: var(--primary-600);
+/* HERO */
+.hero { padding: var(--s-9) 0 var(--s-8); }
+.hero-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
+  gap: var(--s-7);
+  align-items: center;
+}
+@media (max-width: 880px) {
+  .hero-grid { grid-template-columns: 1fr; gap: var(--s-7); }
 }
 
-.nav-github {
-    background: var(--gray-900);
-    color: white;
-    padding: var(--space-2) var(--space-4);
-    border-radius: var(--radius-md);
-    transition: var(--transition-fast);
+.eyebrow {
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: var(--s-4);
 }
 
-.nav-github:hover {
-    background: var(--gray-800);
-    color: white;
-    transform: translateY(-1px);
+.hero h1 {
+  font-size: clamp(1.9rem, 4.5vw, 2.85rem);
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  font-weight: 700;
+  margin-bottom: var(--s-5);
+  color: var(--fg);
+}
+.hero h1 code {
+  background: transparent;
+  color: var(--accent);
+  padding: 0;
+  font-size: 0.9em;
 }
 
-.github-icon {
-    width: 1rem;
-    height: 1rem;
-    fill: currentColor;
-}
-
-/* Hero Section */
-.hero {
-    padding: var(--space-24) 0 var(--space-20);
-    background: linear-gradient(135deg, var(--gray-50) 0%, white 100%);
-    position: relative;
-    overflow: hidden;
-}
-
-.hero-container {
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 0 var(--space-4);
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: var(--space-16);
-    align-items: center;
-}
-
-.hero-badge {
-    display: inline-flex;
-    align-items: center;
-    background: var(--primary-50);
-    border: 1px solid var(--primary-600);
-    border-radius: var(--radius-xl);
-    padding: var(--space-2) var(--space-4);
-    margin-bottom: var(--space-6);
-}
-
-.badge-text {
-    font-size: 0.875rem;
-    font-weight: 600;
-    color: var(--primary-600);
-}
-
-.hero-title {
-    font-size: 3.5rem;
-    font-weight: 800;
-    line-height: 1.1;
-    margin-bottom: var(--space-6);
-    letter-spacing: -0.02em;
-}
-
-.gradient-text {
-    background: linear-gradient(135deg, var(--primary-600), var(--primary-700));
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-}
-
-.hero-description {
-    font-size: 1.25rem;
-    color: var(--gray-600);
-    margin-bottom: var(--space-8);
-    line-height: 1.6;
+.lede {
+  font-size: clamp(1rem, 1.7vw, 1.125rem);
+  color: var(--fg-muted);
+  max-width: 36rem;
+  margin-bottom: var(--s-6);
 }
 
 .hero-actions {
-    display: flex;
-    gap: var(--space-4);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--s-3);
+  margin-bottom: var(--s-5);
 }
 
-.btn {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--space-2);
-    padding: var(--space-3) var(--space-6);
-    border-radius: var(--radius-md);
-    font-weight: 600;
-    font-size: 1rem;
-    text-decoration: none;
-    transition: var(--transition-fast);
-    border: none;
-    cursor: pointer;
+.install {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--s-2);
+  padding: 0.55rem 0.75rem;
+  background: var(--code-bg);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  font-family: var(--font-mono);
+  font-size: 0.875rem;
+  color: var(--code-fg);
 }
-
-.btn-primary {
-    background: var(--primary-600);
-    color: white;
-    box-shadow: var(--shadow-md);
-}
-
-.btn-primary:hover {
-    background: var(--primary-700);
-    transform: translateY(-2px);
-    box-shadow: var(--shadow-lg);
-}
-
-.btn-secondary {
-    background: white;
-    color: var(--gray-800);
-    border: 1px solid var(--gray-300);
-    box-shadow: var(--shadow-sm);
-}
-
-.btn-secondary:hover {
-    background: var(--gray-50);
-    border-color: var(--gray-400);
-    transform: translateY(-2px);
-    box-shadow: var(--shadow-md);
-}
-
-.btn-icon {
-    width: 1rem;
-    height: 1rem;
-    stroke: currentColor;
-    stroke-width: 2;
-    fill: none;
-}
-
-.hero-visual {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-}
-
-.performance-chart-container {
-    width: 100%;
-    max-width: 500px;
-    height: 300px;
-    background: white;
-    border-radius: var(--radius-xl);
-    box-shadow: var(--shadow-xl);
-    padding: var(--space-6);
-    border: 1px solid var(--gray-200);
-}
-
-/* Sections */
-.section-header {
-    text-align: center;
-    margin-bottom: var(--space-16);
-}
-
-.section-title {
-    font-size: 2.5rem;
-    font-weight: 700;
-    color: var(--gray-900);
-    margin-bottom: var(--space-4);
-    letter-spacing: -0.02em;
-}
-
-.section-description {
-    font-size: 1.25rem;
-    color: var(--gray-600);
-    max-width: 600px;
-    margin: 0 auto;
-    line-height: 1.6;
-}
-
-/* Features Section */
-.features {
-    padding: var(--space-20) 0;
-    background: white;
-}
-
-.features-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
-    gap: var(--space-8);
-}
-
-.feature-card {
-    background: white;
-    border: 1px solid var(--gray-200);
-    border-radius: var(--radius-xl);
-    padding: var(--space-8);
-    transition: var(--transition-normal);
-    box-shadow: var(--shadow-sm);
-}
-
-.feature-card:hover {
-    transform: translateY(-4px);
-    box-shadow: var(--shadow-lg);
-    border-color: var(--primary-200);
-}
-
-.feature-icon {
-    font-size: 2.5rem;
-    margin-bottom: var(--space-4);
-    display: block;
-}
-
-.feature-title {
-    font-size: 1.5rem;
-    font-weight: 600;
-    color: var(--gray-900);
-    margin-bottom: var(--space-3);
-}
-
-.feature-description {
-    color: var(--gray-600);
-    line-height: 1.6;
-}
-
-/* Benchmarks Section */
-.benchmarks {
-    padding: var(--space-20) 0;
-    background: var(--gray-50);
-}
-
-.benchmark-table-container {
-    background: white;
-    border-radius: var(--radius-xl);
-    box-shadow: var(--shadow-lg);
-    overflow: hidden;
-    margin-bottom: var(--space-16);
-    border: 1px solid var(--gray-200);
-}
-
-.benchmark-table {
-    width: 100%;
-    border-collapse: collapse;
-}
-
-.benchmark-table th {
-    background: var(--gray-50);
-    color: var(--gray-900);
-    font-weight: 600;
-    padding: var(--space-4);
-    text-align: left;
-    border-bottom: 1px solid var(--gray-200);
-    font-size: 0.875rem;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-}
-
-.benchmark-table td {
-    padding: var(--space-4);
-    border-bottom: 1px solid var(--gray-100);
-    font-size: 0.875rem;
-}
-
-.benchmark-table tbody tr:hover {
-    background: var(--gray-50);
-}
-
-.logma-row {
-    background: var(--primary-50);
-}
-
-.logma-row:hover {
-    background: var(--primary-100);
-}
-
-.advantage {
-    color: var(--green-600);
-    font-weight: 600;
-}
-
-.benchmark-chart-container {
-    background: white;
-    border-radius: var(--radius-xl);
-    box-shadow: var(--shadow-lg);
-    padding: var(--space-8);
-    border: 1px solid var(--gray-200);
-    position: relative;
-}
-
-.chart-title {
-    font-size: 1.5rem;
-    font-weight: 600;
-    color: var(--gray-900);
-    margin-bottom: var(--space-6);
-    text-align: center;
-}
-
-.chart-loading {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    text-align: center;
-    color: var(--gray-500);
-}
-
-.spinner {
-    width: 2rem;
-    height: 2rem;
-    border: 2px solid var(--gray-200);
-    border-top: 2px solid var(--primary-600);
-    border-radius: 50%;
-    animation: spin 1s linear infinite;
-    margin: 0 auto var(--space-4);
-}
-
-@keyframes spin {
-    0% { transform: rotate(0deg); }
-    100% { transform: rotate(360deg); }
-}
-
-/* Quick Start Section */
-.quick-start {
-    padding: var(--space-20) 0;
-    background: white;
-}
-
-.code-examples {
-    display: grid;
-    gap: var(--space-8);
-}
-
-.code-example {
-    background: white;
-    border: 1px solid var(--gray-200);
-    border-radius: var(--radius-xl);
-    overflow: hidden;
-    box-shadow: var(--shadow-lg);
-}
-
-.code-title {
-    font-size: 1.25rem;
-    font-weight: 600;
-    color: var(--gray-900);
-    padding: var(--space-6) var(--space-6) 0;
-    margin-bottom: var(--space-4);
-}
-
-.code-block {
-    position: relative;
-    background: var(--gray-900);
-    color: var(--gray-100);
-    padding: var(--space-6);
-    overflow-x: auto;
-}
-
-.code-block pre {
-    font-family: var(--font-mono);
-    font-size: 0.875rem;
-    line-height: 1.6;
-    margin: 0;
-}
+.install code { background: transparent; padding: 0; }
+.install-prompt { color: var(--fg-faint); user-select: none; }
 
 .copy-btn {
-    position: absolute;
-    top: var(--space-4);
-    right: var(--space-4);
-    background: var(--gray-800);
-    border: 1px solid var(--gray-600);
-    border-radius: var(--radius-md);
-    padding: var(--space-2);
-    color: var(--gray-300);
-    cursor: pointer;
-    transition: var(--transition-fast);
-    display: flex;
-    align-items: center;
-    justify-content: center;
+  font: inherit;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.25rem 0.55rem;
+  background: transparent;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--r-sm);
+  color: var(--fg-muted);
+  cursor: pointer;
+  font-family: var(--font-sans);
+}
+.copy-btn:hover { color: var(--fg); border-color: var(--accent); }
+.copy-btn.copied { color: var(--accent); border-color: var(--accent); }
+
+.cta-primary {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--s-2);
+  padding: 0.6rem 1.05rem;
+  background: var(--accent);
+  color: var(--accent-fg);
+  border-radius: var(--r-md);
+  font-weight: 600;
+  font-size: 0.95rem;
+  text-decoration: none;
+  transition: transform 0.12s ease, background 0.12s ease;
+}
+.cta-primary:hover { background: var(--accent-hover); color: var(--accent-fg); text-decoration: none; transform: translateY(-1px); }
+
+.trust-strip {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--s-4);
+  font-size: 0.8rem;
+  color: var(--fg-faint);
+}
+.trust-strip li { display: inline-flex; align-items: center; }
+.trust-strip li + li::before {
+  content: "·";
+  margin-right: var(--s-4);
+  color: var(--border-strong);
+}
+.trust-strip a { color: var(--fg-faint); text-decoration: underline; text-decoration-color: var(--border-strong); text-underline-offset: 3px; }
+.trust-strip a:hover { color: var(--fg); }
+
+/* Hero demo terminal */
+.hero-demo { position: relative; }
+.terminal {
+  background: var(--terminal-bg);
+  color: var(--terminal-fg);
+  border-radius: var(--r-lg);
+  overflow: hidden;
+  box-shadow: var(--shadow-md);
+  font-family: var(--font-mono);
+  font-size: 0.84rem;
+  line-height: 1.65;
+  border: 1px solid var(--border);
+}
+.terminal-bar {
+  display: flex;
+  gap: 6px;
+  padding: 10px 12px;
+  background: rgba(255, 255, 255, 0.04);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+.terminal-bar span {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #4b5563;
+}
+.terminal-bar span:nth-child(1) { background: #ef4444; }
+.terminal-bar span:nth-child(2) { background: #f59e0b; }
+.terminal-bar span:nth-child(3) { background: #10b981; }
+.terminal-body { padding: var(--s-4) var(--s-5); white-space: pre; overflow-x: auto; }
+
+.tk-key { color: var(--tk-key); }
+.tk-str { color: var(--tk-str); }
+.tk-num { color: var(--tk-num); }
+.tk-kw  { color: var(--tk-kw); }
+.tk-fn  { color: var(--tk-fn); }
+.tk-cm  { color: var(--tk-cm); }
+.tk-hl  { background: var(--tk-hl-bg); display: inline-block; padding: 0 4px; border-radius: 3px; }
+
+.hero-demo-note {
+  margin-top: var(--s-4);
+  font-size: 0.85rem;
+  color: var(--fg-faint);
+  max-width: 28rem;
 }
 
-.copy-btn:hover {
-    background: var(--gray-700);
-    color: white;
+/* What's new strip */
+.whatsnew {
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  padding: var(--s-5) 0;
+  background: var(--bg-alt);
+}
+.whatsnew-label {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--fg-faint);
+  margin-bottom: var(--s-3);
+}
+.whatsnew-list {
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: var(--s-3);
+}
+.whatsnew-list a {
+  display: block;
+  padding: var(--s-3) var(--s-4);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  color: var(--fg);
+  text-decoration: none;
+  transition: border-color 0.12s ease, transform 0.12s ease;
+}
+.whatsnew-list a:hover { border-color: var(--accent); transform: translateY(-1px); text-decoration: none; }
+.whatsnew-list strong { display: block; font-size: 0.92rem; margin-bottom: var(--s-1); color: var(--fg); }
+.whatsnew-list span { display: block; font-size: 0.82rem; color: var(--fg-muted); }
+
+/* Sections */
+.section { padding: var(--s-9) 0; }
+.section-alt { background: var(--bg-alt); }
+.section h2 {
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  font-weight: 700;
+  letter-spacing: -0.015em;
+  margin-bottom: var(--s-4);
+  color: var(--fg);
+}
+.section-lede {
+  font-size: 1.05rem;
+  color: var(--fg-muted);
+  max-width: 44rem;
+  margin-bottom: var(--s-6);
 }
 
-.copy-btn svg {
-    width: 1rem;
-    height: 1rem;
-    fill: currentColor;
+/* Jobs grid */
+.jobs-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: var(--s-4);
+  margin-bottom: var(--s-6);
+}
+.job-card {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  padding: var(--s-5);
+  transition: border-color 0.12s ease;
+}
+.section-alt .job-card { background: var(--bg-alt); }
+.job-card:hover { border-color: var(--accent); }
+.job-job {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: var(--s-2);
+}
+.job-card h3 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin-bottom: var(--s-3);
+  color: var(--fg);
+}
+.job-card p { color: var(--fg-muted); font-size: 0.93rem; margin-bottom: var(--s-4); }
+.job-card a { font-weight: 600; font-size: 0.9rem; }
+
+.why-honest {
+  margin-top: var(--s-4);
+  padding: var(--s-4) var(--s-5);
+  background: var(--bg-alt);
+  border-left: 3px solid var(--accent);
+  color: var(--fg-muted);
+  font-size: 0.95rem;
+  border-radius: 0 var(--r-md) var(--r-md) 0;
+}
+.section-alt .why-honest { background: var(--bg); }
+
+/* Diff grid (slog vs bolt) */
+.diff-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--s-4);
+  margin-bottom: var(--s-5);
+}
+@media (max-width: 880px) { .diff-grid { grid-template-columns: 1fr; } }
+
+.diff-pane {
+  background: var(--terminal-bg);
+  color: var(--terminal-fg);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  overflow: hidden;
+  box-shadow: var(--shadow-sm);
+}
+.diff-pane figcaption {
+  padding: 0.6rem var(--s-4);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  font-weight: 600;
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--fg-faint);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+.diff-pane-after figcaption { color: var(--accent); }
+.diff-pane pre {
+  padding: var(--s-4);
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  line-height: 1.6;
+  overflow-x: auto;
+  white-space: pre;
+}
+.diff-foot {
+  font-size: 0.92rem;
+  color: var(--fg-muted);
 }
 
-/* Documentation Section */
-.docs {
-    padding: var(--space-20) 0;
-    background: var(--gray-50);
+/* Code grid (quickstart) */
+.code-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: var(--s-4);
+  margin-bottom: var(--s-5);
 }
+.code-block {
+  background: var(--terminal-bg);
+  color: var(--terminal-fg);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  overflow: hidden;
+}
+.code-block header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.6rem var(--s-4);
+  background: rgba(255, 255, 255, 0.03);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+.code-block h3 {
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--fg-faint);
+}
+.code-block h3 code { background: transparent; color: var(--accent); padding: 0; }
+.code-block pre {
+  padding: var(--s-4);
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  line-height: 1.65;
+  overflow-x: auto;
+  white-space: pre;
+}
+.code-block .copy-btn { color: var(--terminal-fg); border-color: rgba(255, 255, 255, 0.18); }
+.code-block .copy-btn:hover { color: var(--accent); border-color: var(--accent); }
 
-.docs-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: var(--space-6);
+.next-steps {
+  font-size: 0.92rem;
+  color: var(--fg-muted);
 }
+.next-steps a { font-weight: 500; }
 
-.doc-card {
-    background: white;
-    border: 1px solid var(--gray-200);
-    border-radius: var(--radius-xl);
-    padding: var(--space-6);
-    text-decoration: none;
-    transition: var(--transition-normal);
-    box-shadow: var(--shadow-sm);
-    display: block;
+/* Performance section */
+.bench-table-wrap {
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  overflow: hidden;
+  margin-bottom: var(--s-3);
+  background: var(--bg);
 }
+.section-alt .bench-table-wrap { background: var(--bg-alt); }
+.bench-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+.bench-table th, .bench-table td {
+  padding: 0.7rem var(--s-4);
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+}
+.bench-table tbody tr:last-child td { border-bottom: none; }
+.bench-table th {
+  font-weight: 600;
+  color: var(--fg-faint);
+  background: var(--bg-alt);
+  font-size: 0.82rem;
+  letter-spacing: 0.02em;
+}
+.section-alt .bench-table th { background: var(--bg); }
+.bench-table .num { text-align: right; font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
+.bench-table .bench-self { background: color-mix(in srgb, var(--accent) 8%, transparent); }
+.bench-table .bench-self td { font-weight: 600; }
+.bench-foot { font-size: 0.85rem; color: var(--fg-faint); }
 
-.doc-card:hover {
-    transform: translateY(-4px);
-    box-shadow: var(--shadow-lg);
-    border-color: var(--primary-200);
+/* Trust block */
+.trust-block { padding: var(--s-8) 0; border-top: 1px solid var(--border); background: var(--bg-alt); }
+.trust-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: var(--s-5);
 }
-
-.doc-icon {
-    font-size: 2rem;
-    margin-bottom: var(--space-4);
-    display: block;
+.trust-row h3 {
+  font-size: 0.92rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  margin-bottom: var(--s-2);
+  color: var(--fg);
 }
-
-.doc-title {
-    font-size: 1.25rem;
-    font-weight: 600;
-    color: var(--gray-900);
-    margin-bottom: var(--space-3);
-}
-
-.doc-description {
-    color: var(--gray-600);
-    line-height: 1.6;
-}
+.trust-row p { font-size: 0.9rem; color: var(--fg-muted); }
 
 /* Footer */
-.footer {
-    background: var(--gray-900);
-    color: white;
-    padding: var(--space-16) 0 var(--space-8);
+.site-footer {
+  padding: var(--s-6) 0;
+  border-top: 1px solid var(--border);
+  background: var(--bg);
+  font-size: 0.88rem;
+  color: var(--fg-muted);
 }
-
-.footer-content {
-    display: grid;
-    grid-template-columns: 1fr 2fr;
-    gap: var(--space-16);
-    margin-bottom: var(--space-12);
+.footer-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--s-4);
 }
-
 .footer-brand {
-    max-width: 300px;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--s-2);
+  color: var(--fg-muted);
 }
-
-.footer-logo {
-    height: 2rem;
-    margin-bottom: var(--space-4);
-    filter: brightness(0) invert(1);
-}
-
-.footer-description {
-    color: var(--gray-400);
-    line-height: 1.6;
-}
+.footer-brand a { color: var(--fg); }
+.footer-brand a:hover { color: var(--accent); }
 
 .footer-links {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: var(--space-8);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--s-4);
 }
-
-.footer-section h4 {
-    color: white;
-    font-weight: 600;
-    margin-bottom: var(--space-4);
+.footer-links a {
+  color: var(--fg-faint);
+  font-size: 0.85rem;
+  text-decoration: none;
 }
+.footer-links a:hover { color: var(--fg); text-decoration: underline; }
 
-.footer-section a {
-    display: block;
-    color: var(--gray-400);
-    text-decoration: none;
-    margin-bottom: var(--space-2);
-    transition: var(--transition-fast);
-}
-
-.footer-section a:hover {
-    color: white;
-}
-
-.footer-bottom {
-    border-top: 1px solid var(--gray-800);
-    padding-top: var(--space-8);
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    color: var(--gray-500);
-    font-size: 0.875rem;
-}
-
-.footer-stats {
-    display: flex;
-    gap: var(--space-4);
-}
-
-.stat {
-    background: var(--gray-800);
-    padding: var(--space-1) var(--space-3);
-    border-radius: var(--radius-md);
-    font-size: 0.75rem;
-    font-weight: 500;
-}
-
-/* Responsive Design */
-@media (max-width: 1024px) {
-    .hero-container {
-        grid-template-columns: 1fr;
-        gap: var(--space-12);
-        text-align: center;
-    }
-    
-    .hero-title {
-        font-size: 3rem;
-    }
-    
-    .features-grid {
-        grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-    }
-    
-    .footer-content {
-        grid-template-columns: 1fr;
-        gap: var(--space-8);
-    }
-    
-    .footer-links {
-        grid-template-columns: repeat(2, 1fr);
-    }
-}
-
-@media (max-width: 768px) {
-    .nav-links {
-        gap: var(--space-4);
-    }
-    
-    .nav-link {
-        font-size: 0.8rem;
-    }
-    
-    .hero {
-        padding: var(--space-20) 0 var(--space-16);
-    }
-    
-    .hero-title {
-        font-size: 2.5rem;
-    }
-    
-    .hero-description {
-        font-size: 1.125rem;
-    }
-    
-    .hero-actions {
-        flex-direction: column;
-        align-items: center;
-    }
-    
-    .section-title {
-        font-size: 2rem;
-    }
-    
-    .features-grid {
-        grid-template-columns: 1fr;
-    }
-    
-    .benchmark-table {
-        font-size: 0.75rem;
-    }
-    
-    .footer-links {
-        grid-template-columns: 1fr;
-    }
-    
-    .footer-bottom {
-        flex-direction: column;
-        gap: var(--space-4);
-        text-align: center;
-    }
-}
-
-@media (max-width: 480px) {
-    .container {
-        padding: 0 var(--space-3);
-    }
-    
-    .nav-container {
-        padding: 0 var(--space-3);
-    }
-    
-    .hero-title {
-        font-size: 2rem;
-    }
-    
-    .section-title {
-        font-size: 1.75rem;
-    }
-    
-    .features-grid {
-        grid-template-columns: 1fr;
-        gap: var(--space-4);
-    }
-    
-    .feature-card,
-    .doc-card,
-    .code-example {
-        padding: var(--space-4);
-    }
-}
-
-/* Utility Classes */
-.text-center { text-align: center; }
-.text-left { text-align: left; }
-.text-right { text-align: right; }
-
-.hidden { display: none; }
-.visible { display: block; }
-
-.sr-only {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
-}
+/* Selection */
+::selection { background: var(--accent); color: var(--accent-fg); }

--- a/index.html
+++ b/index.html
@@ -69,6 +69,14 @@
             </a>
           </div>
 
+          <p class="badges-row" aria-label="Project signals">
+            <a href="https://github.com/felixgeelhaar/bolt/actions/workflows/nox.yml">
+              <img src="assets/badge-nox.svg" alt="Nox security grade" height="20">
+            </a>
+            <a href="https://github.com/felixgeelhaar/bolt/actions/workflows/ci.yml">
+              <img src="assets/badge-coverage.svg" alt="Test coverage" height="20">
+            </a>
+          </p>
           <ul class="trust-strip" aria-label="Project signals">
             <li>MIT</li>
             <li>Go 1.24+</li>

--- a/index.html
+++ b/index.html
@@ -3,243 +3,390 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Bolt — Zero-allocation slog.Handler for Go</title>
-  <meta name="description" content="Zero-allocation slog.Handler for Go with first-class OpenTelemetry trace/span injection. Passes testing/slogtest.TestHandler conformance.">
+  <title>Bolt — slog handler that closes the logs↔traces loop</title>
+  <meta name="description" content="Zero-allocation slog.Handler for Go that auto-injects OpenTelemetry trace_id and span_id from context. testing/slogtest.TestHandler conformant. SLSA-3 signed releases.">
+  <meta name="theme-color" content="#0B0F19">
   <link rel="icon" type="image/png" href="assets/favicon.png">
   <link rel="stylesheet" href="assets/style.css">
-  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js" defer></script>
+  <link rel="canonical" href="https://felixgeelhaar.github.io/bolt/">
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="Bolt — slog handler that closes the logs↔traces loop">
+  <meta property="og:description" content="Zero-allocation slog.Handler for Go with first-class OpenTelemetry trace/span injection.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://felixgeelhaar.github.io/bolt/">
+  <meta property="og:image" content="https://felixgeelhaar.github.io/bolt/assets/bolt_logo.png">
 </head>
 <body>
-  <nav class="navbar">
-    <div class="nav-container">
-      <a href="#" class="nav-brand">
-        <img src="assets/bolt_logo.png" alt="Bolt" width="36" height="36">
-        <span>Bolt</span>
+  <a class="skip" href="#main">Skip to content</a>
+
+  <header class="navbar" role="banner">
+    <div class="container nav-row">
+      <a class="brand" href="#" aria-label="Bolt home">
+        <img src="assets/bolt_logo.png" alt="" width="32" height="32">
+        <span class="brand-text">bolt</span>
       </a>
-      <ul class="nav-links">
-        <li><a href="#why">Why bolt</a></li>
-        <li><a href="#performance">Benchmarks</a></li>
-        <li><a href="#quickstart">Quick start</a></li>
-        <li><a href="https://github.com/felixgeelhaar/bolt/tree/main/docs">Docs</a></li>
-        <li><a href="https://pkg.go.dev/github.com/felixgeelhaar/bolt">API</a></li>
-        <li><a href="https://github.com/felixgeelhaar/bolt" class="cta">GitHub</a></li>
-      </ul>
-    </div>
-  </nav>
-
-  <header class="hero">
-    <div class="hero-container">
-      <h1>Zero-allocation <code>slog.Handler</code> for Go</h1>
-      <p class="hero-tagline">
-        Drop-in <code>log/slog</code> backend with first-class OpenTelemetry
-        trace/span injection. Passes <code>testing/slogtest.TestHandler</code>
-        conformance. SLSA-3 signed releases.
-      </p>
-
-      <div class="hero-badges">
-        <a href="https://github.com/felixgeelhaar/bolt/actions/workflows/ci.yml">
-          <img src="https://github.com/felixgeelhaar/bolt/actions/workflows/ci.yml/badge.svg" alt="CI">
-        </a>
-        <a href="https://github.com/felixgeelhaar/bolt/actions/workflows/nox.yml">
-          <img src="https://github.com/felixgeelhaar/bolt/actions/workflows/nox.yml/badge.svg" alt="Nox Security">
-        </a>
-        <a href="https://codecov.io/gh/felixgeelhaar/bolt">
-          <img src="https://codecov.io/gh/felixgeelhaar/bolt/branch/main/graph/badge.svg" alt="codecov">
-        </a>
-        <a href="https://pkg.go.dev/github.com/felixgeelhaar/bolt">
-          <img src="https://pkg.go.dev/badge/github.com/felixgeelhaar/bolt.svg" alt="Go Reference">
-        </a>
-        <a href="https://opensource.org/licenses/MIT">
-          <img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT">
-        </a>
-      </div>
-
-      <div class="hero-cta">
-        <code class="install">go get github.com/felixgeelhaar/bolt</code>
-        <a class="button-primary" href="https://github.com/felixgeelhaar/bolt#quick-start">Quick start →</a>
-      </div>
+      <nav class="nav-links" aria-label="Primary">
+        <a href="#why">Why bolt</a>
+        <a href="#trace">Trace-correlated</a>
+        <a href="#start">Quick start</a>
+        <a href="https://github.com/felixgeelhaar/bolt/tree/main/docs">Docs</a>
+        <a href="https://pkg.go.dev/github.com/felixgeelhaar/bolt">API</a>
+      </nav>
+      <a href="https://github.com/felixgeelhaar/bolt" class="github-cta" rel="noopener">
+        <svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"></path></svg>
+        Star
+      </a>
+      <button class="theme-toggle" type="button" aria-label="Toggle colour theme">
+        <svg class="theme-icon-sun" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+        <svg class="theme-icon-moon" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/></svg>
+      </button>
     </div>
   </header>
 
-  <section id="why" class="why">
-    <div class="container">
-      <h2>Why bolt vs slog / zerolog / zap</h2>
-      <p class="section-tagline">A focused decision tree, not a feature shootout.</p>
-
-      <table class="decision-table">
-        <thead>
-          <tr><th>You want…</th><th>Pick</th></tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>The standard library API, no third-party dependency, no perf budget.</td>
-            <td><code>log/slog</code> (stdlib)</td>
-          </tr>
-          <tr class="pick-bolt">
-            <td>Zero-alloc speed, slog ergonomics, <strong>and</strong> first-class OTel trace/span injection.</td>
-            <td><strong>bolt</strong></td>
-          </tr>
-          <tr class="pick-bolt">
-            <td>The <code>zerolog</code>-style chained API with the smallest production diff and a clear migration path.</td>
-            <td><strong>bolt</strong> + <a href="https://github.com/felixgeelhaar/bolt/blob/main/docs/how-to/migrate-from-zerolog.md">migration guide</a></td>
-          </tr>
-          <tr>
-            <td><code>zap</code>'s typed-constructor API.</td>
-            <td>bolt's chained API; see <a href="https://github.com/felixgeelhaar/bolt/blob/main/docs/how-to/migrate-from-zap.md">migration guide</a></td>
-          </tr>
-        </tbody>
-      </table>
-
-      <p class="why-honest">
-        Bolt is <strong>not</strong> trying to win a single-digit-nanosecond benchmark
-        shootout. It's the slog handler you can ship into a production Go service without
-        giving up structured perf, OTel correlation, or the slog ergonomics other teams
-        already learned.
-      </p>
-    </div>
-  </section>
-
-  <section id="performance" class="performance">
-    <div class="container">
-      <h2>Performance</h2>
-      <p class="section-tagline">
-        Zero allocations on the hot path; latency varies by hardware. CI gate
-        <code>BenchmarkZeroAllocation</code> requires <code>0 allocs/op</code>; the
-        <a href="https://github.com/felixgeelhaar/bolt/blob/main/.github/workflows/pr-checks.yml"><code>benchstat</code> regression workflow</a>
-        catches statistically significant deltas (Mann–Whitney U-test, α=0.05).
-      </p>
-
-      <div class="chart-container">
-        <canvas id="performanceChart"></canvas>
-      </div>
-
-      <table class="bench-table">
-        <thead>
-          <tr><th>Library</th><th>ns/op</th><th>Allocations</th></tr>
-        </thead>
-        <tbody>
-          <tr><td><strong>Bolt</strong></td><td><strong>127.1</strong></td><td><strong>0</strong></td></tr>
-          <tr><td>Zerolog</td><td>175.4</td><td>0</td></tr>
-          <tr><td>Zap</td><td>189.7</td><td>1</td></tr>
-          <tr><td>Logrus</td><td>2847</td><td>23</td></tr>
-        </tbody>
-      </table>
-      <p class="bench-caveat">
-        Numbers from a representative recent CI run. Reproduce locally with
-        <code>go test -bench=. -benchmem -run=^$</code>.
-      </p>
-    </div>
-  </section>
-
-  <section id="quickstart" class="quickstart">
-    <div class="container">
-      <h2>Quick start</h2>
-
-      <div class="code-grid">
-        <div class="code-block">
-          <h3>As a <code>slog.Handler</code> (recommended)</h3>
-          <pre><code>package main
-
-import (
-    "log/slog"
-    "os"
-
-    "github.com/felixgeelhaar/bolt"
-)
-
-func main() {
-    logger := slog.New(bolt.NewSlogHandler(os.Stdout, nil))
-    slog.SetDefault(logger)
-    slog.Info("server starting", "service", "api", "port", 8080)
-}</code></pre>
-        </div>
-
-        <div class="code-block">
-          <h3>Chained-builder API (hot paths)</h3>
-          <pre><code>package main
-
-import (
-    "os"
-
-    "github.com/felixgeelhaar/bolt"
-)
-
-func main() {
-    log := bolt.New(bolt.NewJSONHandler(os.Stdout))
-    log.Info().
-        Str("service", "api").
-        Int("port", 8080).
-        Msg("server starting")
-}</code></pre>
-        </div>
-      </div>
-
-      <p class="quickstart-next">
-        Next: <a href="https://github.com/felixgeelhaar/bolt/blob/main/docs/tutorial/quickstart.md">five-minute tutorial</a>
-        · <a href="https://github.com/felixgeelhaar/bolt/tree/main/docs/how-to">migration guides</a>
-        · <a href="https://github.com/felixgeelhaar/bolt/tree/main/docs/reference">API reference</a>
-        · <a href="https://github.com/felixgeelhaar/bolt/tree/main/docs/explanation">design rationale</a>
-      </p>
-    </div>
-  </section>
-
-  <section id="security" class="security">
-    <div class="container">
-      <h2>Supply-chain hardness</h2>
-      <p class="section-tagline">
-        A logging library is imported by every service, so signed artefacts and
-        provenance are not optional.
-      </p>
-
-      <div class="security-grid">
-        <div class="security-item">
-          <h3>Per-PR security scan</h3>
-          <p>
-            <a href="https://github.com/nox-hq/nox"><code>nox</code></a> runs
-            on every PR — OSV-aware vulnerability + secret scan, baseline-tracked
-            false positives. Replaces dependabot for security-driven gomod
-            upgrades via the
-            <a href="https://github.com/felixgeelhaar/bolt/blob/main/.github/workflows/nox-remediate.yml"><code>nox-remediate</code></a>
-            scheduled workflow.
+  <main id="main">
+    <!-- HERO -->
+    <section class="hero">
+      <div class="container hero-grid">
+        <div class="hero-copy">
+          <p class="eyebrow">For Go services on log/slog + OpenTelemetry</p>
+          <h1>The <code>slog.Handler</code> that closes the logs↔traces loop.</h1>
+          <p class="lede">
+            Drop-in <code>log/slog</code> backend. Auto-injects
+            <code>trace_id</code> and <code>span_id</code> from
+            <code>context.Context</code>. Zero allocations on the hot path.
+            Passes <code>testing/slogtest.TestHandler</code> conformance.
           </p>
+
+          <div class="hero-actions">
+            <div class="install" data-copy-target="install-cmd">
+              <span class="install-prompt" aria-hidden="true">$</span>
+              <code id="install-cmd">go get github.com/felixgeelhaar/bolt</code>
+              <button class="copy-btn" type="button" data-copy="install-cmd" aria-label="Copy install command">Copy</button>
+            </div>
+            <a class="cta-primary" href="https://github.com/felixgeelhaar/bolt/blob/main/docs/tutorial/quickstart.md">
+              5-min quickstart →
+            </a>
+          </div>
+
+          <ul class="trust-strip" aria-label="Project signals">
+            <li>MIT</li>
+            <li>Go 1.24+</li>
+            <li>0 direct deps</li>
+            <li>SLSA-3 signed</li>
+            <li><a href="https://github.com/felixgeelhaar/bolt/blob/main/SECURITY.md">Security policy</a></li>
+          </ul>
         </div>
-        <div class="security-item">
-          <h3>Signed releases</h3>
+
+        <aside class="hero-demo" aria-label="Trace-correlated log example">
+          <div class="terminal" role="figure" aria-label="JSON output emitted by bolt with auto-injected trace_id and span_id">
+            <div class="terminal-bar"><span></span><span></span><span></span></div>
+            <pre class="terminal-body"><code><span class="tk-key">"level"</span>:<span class="tk-str">"info"</span>,
+<span class="tk-key">"time"</span>:<span class="tk-str">"2026-05-09T11:42:31Z"</span>,
+<span class="tk-key">"service"</span>:<span class="tk-str">"checkout-api"</span>,
+<span class="tk-key">"path"</span>:<span class="tk-str">"/orders"</span>,
+<span class="tk-key">"status"</span>:<span class="tk-num">201</span>,
+<span class="tk-hl"><span class="tk-key">"trace_id"</span>:<span class="tk-str">"4bf92f3577b34da6a3ce929d0e0e4736"</span>,</span>
+<span class="tk-hl"><span class="tk-key">"span_id"</span>:<span class="tk-str">"00f067aa0ba902b7"</span>,</span>
+<span class="tk-key">"message"</span>:<span class="tk-str">"order placed"</span></code></pre>
+          </div>
+          <p class="hero-demo-note">
+            Highlighted fields come for free from
+            <code>logger.Ctx(ctx)</code> — no manual extraction, no
+            middleware, no custom encoder.
+          </p>
+        </aside>
+      </div>
+    </section>
+
+    <!-- WHAT'S NEW STRIP -->
+    <section class="whatsnew" aria-label="Recently shipped">
+      <div class="container">
+        <p class="whatsnew-label">Recently shipped</p>
+        <ul class="whatsnew-list">
+          <li>
+            <a href="https://github.com/felixgeelhaar/bolt/blob/main/docs/explanation/hook-v2.md">
+              <strong>Hook v2 / EventHook</strong>
+              <span>Field-aware interception for redaction, tagging, cost accounting.</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://github.com/felixgeelhaar/bolt/tree/main/genai">
+              <strong>bolt/genai sub-module</strong>
+              <span>OTel GenAI semconv field names. Langfuse / Phoenix / Braintrust ingest direct.</span>
+            </a>
+          </li>
+          <li>
+            <a href="https://github.com/felixgeelhaar/bolt/blob/main/SECURITY.md#-verifying-release-artefacts">
+              <strong>SLSA-3 signed releases</strong>
+              <span>cosign keyless · SPDX SBOM · slsa-github-generator provenance.</span>
+            </a>
+          </li>
+        </ul>
+      </div>
+    </section>
+
+    <!-- WHY BOLT (JTBD-first) -->
+    <section id="why" class="section">
+      <div class="container">
+        <h2>Pick the tool by the job, not the tagline.</h2>
+        <p class="section-lede">
+          Three jobs developers come to bolt for. Each links to the
+          how-to that gets you there.
+        </p>
+
+        <div class="jobs-grid">
+          <article class="job-card">
+            <p class="job-job">I'm on slog</p>
+            <h3>I want OTel correlation without a perf cliff.</h3>
+            <p>
+              Stdlib <code>log/slog</code> has no first-class
+              trace/span injection and the JSON handler allocates per
+              attribute. <code>bolt.NewSlogHandler</code> is a
+              drop-in replacement that auto-attaches trace context
+              and keeps the encoder zero-alloc.
+            </p>
+            <a href="https://github.com/felixgeelhaar/bolt/blob/main/docs/how-to/migrate-from-slog.md">
+              Migrate from slog →
+            </a>
+          </article>
+
+          <article class="job-card">
+            <p class="job-job">I'm on zerolog</p>
+            <h3>I want a path off it without rewriting every call site.</h3>
+            <p>
+              bolt's chained API is intentionally close to zerolog's.
+              The migration is mechanical: import-path swap plus a
+              constructor change. Hooks gain a richer
+              <code>EventHook</code> surface (zerolog's hook
+              equivalent — but as a v2 alongside the legacy
+              interface).
+            </p>
+            <a href="https://github.com/felixgeelhaar/bolt/blob/main/docs/how-to/migrate-from-zerolog.md">
+              Migrate from zerolog →
+            </a>
+          </article>
+
+          <article class="job-card">
+            <p class="job-job">I'm building LLM features</p>
+            <h3>I need GenAI semconv logs without a vendor SDK.</h3>
+            <p>
+              <code>bolt/genai</code> ships
+              <code>Call</code>/<code>ToolCall</code> helpers that
+              emit the <a href="https://opentelemetry.io/docs/specs/semconv/gen-ai/">
+              OTel GenAI semantic conventions</a>. Output ingests
+              direct into Langfuse, Arize Phoenix, Braintrust, or the
+              OTel Collector's GenAI processor.
+            </p>
+            <a href="https://github.com/felixgeelhaar/bolt/tree/main/genai">
+              See bolt/genai →
+            </a>
+          </article>
+        </div>
+
+        <p class="why-honest">
+          <strong>Bolt is not</strong> trying to win a
+          single-digit-nanosecond benchmark shootout. The encoder is
+          fast — measurably faster than zerolog and zap on the same
+          hardware — but the wedge is the slog-and-OTel combination,
+          not the headline ns/op.
+        </p>
+      </div>
+    </section>
+
+    <!-- TRACE CORRELATION (the wedge, fully fleshed) -->
+    <section id="trace" class="section section-alt">
+      <div class="container">
+        <h2>Three lines for trace-correlated logs.</h2>
+        <p class="section-lede">
+          The <code>Logger.Ctx(ctx)</code> path attaches the active
+          span's <code>trace_id</code> and <code>span_id</code>
+          automatically. No middleware, no custom encoder, no
+          per-call extraction.
+        </p>
+
+        <div class="diff-grid">
+          <figure class="diff-pane">
+            <figcaption>stdlib slog</figcaption>
+            <pre><code><span class="tk-kw">import</span> <span class="tk-str">"log/slog"</span>
+
+logger := slog.<span class="tk-fn">New</span>(slog.<span class="tk-fn">NewJSONHandler</span>(os.Stdout, <span class="tk-kw">nil</span>))
+
+<span class="tk-cm">// Trace context? You write the extraction yourself.</span>
+sp := trace.<span class="tk-fn">SpanFromContext</span>(ctx).<span class="tk-fn">SpanContext</span>()
+logger.<span class="tk-fn">InfoContext</span>(ctx, <span class="tk-str">"order placed"</span>,
+    <span class="tk-str">"trace_id"</span>, sp.<span class="tk-fn">TraceID</span>().<span class="tk-fn">String</span>(),
+    <span class="tk-str">"span_id"</span>,  sp.<span class="tk-fn">SpanID</span>().<span class="tk-fn">String</span>(),
+)</code></pre>
+          </figure>
+
+          <figure class="diff-pane diff-pane-after">
+            <figcaption>bolt</figcaption>
+            <pre><code><span class="tk-kw">import</span> <span class="tk-str">"github.com/felixgeelhaar/bolt"</span>
+
+logger := bolt.<span class="tk-fn">New</span>(bolt.<span class="tk-fn">NewJSONHandler</span>(os.Stdout))
+
+<span class="tk-cm">// Ctx(ctx) does the extraction once, for everything that follows.</span>
+logger.<span class="tk-fn">Ctx</span>(ctx).<span class="tk-fn">Info</span>().
+    <span class="tk-fn">Msg</span>(<span class="tk-str">"order placed"</span>)</code></pre>
+          </figure>
+        </div>
+
+        <p class="diff-foot">
+          Want the slog API instead?
+          <code>slog.New(bolt.NewSlogHandler(os.Stdout, nil))</code>
+          — same auto-injection, same encoder, every existing slog
+          call site keeps working. Both modes pass
+          <code>testing/slogtest.TestHandler</code>.
+        </p>
+      </div>
+    </section>
+
+    <!-- QUICK START -->
+    <section id="start" class="section">
+      <div class="container">
+        <h2>Quick start</h2>
+        <div class="code-grid">
+          <div class="code-block">
+            <header>
+              <h3>As a <code>slog.Handler</code></h3>
+              <button class="copy-btn" type="button" data-copy="qs-slog">Copy</button>
+            </header>
+            <pre><code id="qs-slog"><span class="tk-kw">package</span> main
+
+<span class="tk-kw">import</span> (
+    <span class="tk-str">"log/slog"</span>
+    <span class="tk-str">"os"</span>
+
+    <span class="tk-str">"github.com/felixgeelhaar/bolt"</span>
+)
+
+<span class="tk-kw">func</span> <span class="tk-fn">main</span>() {
+    h := bolt.<span class="tk-fn">NewSlogHandler</span>(os.Stdout, <span class="tk-kw">nil</span>)
+    slog.<span class="tk-fn">SetDefault</span>(slog.<span class="tk-fn">New</span>(h))
+    slog.<span class="tk-fn">Info</span>(<span class="tk-str">"server starting"</span>, <span class="tk-str">"port"</span>, <span class="tk-num">8080</span>)
+}</code></pre>
+          </div>
+
+          <div class="code-block">
+            <header>
+              <h3>Chained API (hot paths)</h3>
+              <button class="copy-btn" type="button" data-copy="qs-chain">Copy</button>
+            </header>
+            <pre><code id="qs-chain"><span class="tk-kw">package</span> main
+
+<span class="tk-kw">import</span> (
+    <span class="tk-str">"os"</span>
+
+    <span class="tk-str">"github.com/felixgeelhaar/bolt"</span>
+)
+
+<span class="tk-kw">func</span> <span class="tk-fn">main</span>() {
+    log := bolt.<span class="tk-fn">New</span>(bolt.<span class="tk-fn">NewJSONHandler</span>(os.Stdout))
+    log.<span class="tk-fn">Info</span>().
+        <span class="tk-fn">Str</span>(<span class="tk-str">"service"</span>, <span class="tk-str">"api"</span>).
+        <span class="tk-fn">Int</span>(<span class="tk-str">"port"</span>, <span class="tk-num">8080</span>).
+        <span class="tk-fn">Msg</span>(<span class="tk-str">"server starting"</span>)
+}</code></pre>
+          </div>
+        </div>
+
+        <p class="next-steps">
+          Next:
+          <a href="https://github.com/felixgeelhaar/bolt/blob/main/docs/tutorial/quickstart.md">tutorial</a> ·
+          <a href="https://github.com/felixgeelhaar/bolt/tree/main/docs/how-to">migration guides</a> ·
+          <a href="https://github.com/felixgeelhaar/bolt/tree/main/docs/reference">reference</a> ·
+          <a href="https://github.com/felixgeelhaar/bolt/tree/main/docs/explanation">design rationale</a>
+        </p>
+      </div>
+    </section>
+
+    <!-- PERFORMANCE (honest) -->
+    <section id="performance" class="section section-alt">
+      <div class="container">
+        <h2>Performance receipts.</h2>
+        <p class="section-lede">
+          Numbers vary by hardware. The CI gate
+          (<a href="https://github.com/felixgeelhaar/bolt/blob/main/.github/workflows/ci.yml"><code>ci.yml</code></a>)
+          requires <strong>0 allocs/op</strong> on
+          <code>BenchmarkZeroAllocation</code>. The
+          <a href="https://github.com/felixgeelhaar/bolt/blob/main/.github/workflows/pr-checks.yml"><code>benchstat</code> regression workflow</a>
+          fails the PR on statistically significant deltas
+          (Mann–Whitney U-test, α=0.05).
+        </p>
+
+        <div class="bench-table-wrap">
+          <table class="bench-table">
+            <thead>
+              <tr><th>Library</th><th class="num">ns/op</th><th class="num">B/op</th><th class="num">allocs/op</th></tr>
+            </thead>
+            <tbody>
+              <tr class="bench-self">
+                <td>bolt</td><td class="num">127</td><td class="num">0</td><td class="num"><strong>0</strong></td>
+              </tr>
+              <tr><td>zerolog</td><td class="num">175</td><td class="num">0</td><td class="num">0</td></tr>
+              <tr><td>zap</td><td class="num">190</td><td class="num">128</td><td class="num">1</td></tr>
+              <tr><td>logrus</td><td class="num">2,847</td><td class="num">1,737</td><td class="num">23</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="bench-foot">
+          Linux/amd64, GitHub Actions <code>ubuntu-latest</code>.
+          Reproduce locally with
+          <code>go test -bench=. -benchmem -run=^$</code>. The
+          benchstat artefact for each PR is attached to the
+          <code>performance-regression</code> workflow run.
+        </p>
+      </div>
+    </section>
+
+    <!-- TRUST STRIP (compact) -->
+    <section id="security" class="trust-block">
+      <div class="container trust-row">
+        <div>
+          <h3>Supply chain</h3>
           <p>
-            Source archive + SBOM + checksums signed with cosign keyless OIDC
-            (Sigstore). SLSA-3 provenance attestation via
-            <a href="https://github.com/slsa-framework/slsa-github-generator">slsa-github-generator</a>.
-            Verification commands in
+            cosign keyless signatures · SPDX SBOM · SLSA-3 provenance
+            attestation per release. Verification commands in
             <a href="https://github.com/felixgeelhaar/bolt/blob/main/SECURITY.md#-verifying-release-artefacts">SECURITY.md</a>.
           </p>
         </div>
-        <div class="security-item">
-          <h3>Continuous fuzzing</h3>
+        <div>
+          <h3>Continuous security</h3>
           <p>
-            9 <code>Fuzz*</code> targets in <code>fuzz_test.go</code> exercised
-            by the hourly <a href="https://github.com/felixgeelhaar/bolt/blob/main/.github/workflows/fuzz.yml">fuzz workflow</a>
-            and a nightly <a href="https://github.com/felixgeelhaar/bolt/blob/main/.github/workflows/mutation.yml">gremlins mutation-testing run</a>.
-            OSS-Fuzz onboarding scaffolding in
-            <a href="https://github.com/felixgeelhaar/bolt/tree/main/oss-fuzz"><code>oss-fuzz/</code></a>.
+            <a href="https://github.com/nox-hq/nox"><code>nox</code></a>
+            scan per PR · scheduled
+            <code>nox-remediate</code> for OSV-driven upgrades ·
+            hourly fuzz · nightly mutation testing on hot paths.
+          </p>
+        </div>
+        <div>
+          <h3>Governance</h3>
+          <p>
+            Solo maintainer, MIT, response-time SLAs documented
+            in <a href="https://github.com/felixgeelhaar/bolt/blob/main/SECURITY.md">SECURITY.md</a>.
+            <a href="https://github.com/felixgeelhaar/bolt/blob/main/ADOPTERS.md">ADOPTERS.md</a>
+            currently empty — PR yourself in if you ship bolt.
           </p>
         </div>
       </div>
-    </div>
-  </section>
+    </section>
+  </main>
 
   <footer class="site-footer">
-    <div class="container">
-      <p>
-        Bolt is MIT-licensed and maintained by
-        <a href="https://github.com/felixgeelhaar">Felix Geelhaar</a>.
-        Roadmap and governance disclosure in
-        <a href="https://github.com/felixgeelhaar/bolt/blob/main/ROADMAP.md">ROADMAP.md</a>
-        and <a href="https://github.com/felixgeelhaar/bolt/blob/main/SECURITY.md">SECURITY.md</a>.
-      </p>
-      <p>
-        Issues, discussions, and PRs welcome on
-        <a href="https://github.com/felixgeelhaar/bolt">GitHub</a>.
-      </p>
+    <div class="container footer-row">
+      <div class="footer-brand">
+        <img src="assets/bolt_logo.png" alt="" width="24" height="24">
+        <span>bolt — maintained by <a href="https://github.com/felixgeelhaar">Felix Geelhaar</a></span>
+      </div>
+      <nav class="footer-links" aria-label="Footer">
+        <a href="https://github.com/felixgeelhaar/bolt">GitHub</a>
+        <a href="https://pkg.go.dev/github.com/felixgeelhaar/bolt">pkg.go.dev</a>
+        <a href="https://github.com/felixgeelhaar/bolt/tree/main/docs">Docs</a>
+        <a href="https://github.com/felixgeelhaar/bolt/blob/main/ROADMAP.md">Roadmap</a>
+        <a href="https://github.com/felixgeelhaar/bolt/blob/main/CHANGELOG.md">Changelog</a>
+        <a href="https://github.com/felixgeelhaar/bolt/blob/main/LICENSE">License</a>
+      </nav>
     </div>
   </footer>
 


### PR DESCRIPTION
## Summary

Three things bundled, all originating from the user-requested website improvements + follow-up tweaks.

## 1. Modern landing redesign (synthesised from GTM + product + UX expert reviews)

**Lead with the wedge.** Hero now shows the actual differentiator: bolt is the slog handler that closes the logs↔traces loop. Side-by-side terminal demo on the right shows the JSON output with `trace_id` + `span_id` highlighted — visible in 5 seconds.

**Honest momentum.** New "Recently shipped" strip surfaces Hook v2, bolt/genai, SLSA-3 — the previous page hid every shipped feature.

**JTBD framing.** Why-bolt section is three job-cards (slog migrant / zerolog migrant / LLM-features dev) instead of a generic decision table; each links to its migration guide / sub-module.

**Trace-correlation diff.** Concretises the wedge with a stdlib-vs-bolt code comparison (left: 6 lines manual extraction, right: 3 lines auto-injected).

**Performance honesty.** Dropped the Chart.js canvas (loading ~80KB of CDN JS to render 4 bars). Bench table caption now states the hardware and links to the benchstat artefact.

**Trust block compressed** to a 3-column strip covering supply chain, continuous security (nox + nox-remediate + fuzz + mutation), governance.

## 2. Chrome rebuild

- **Dark mode**: full token system (`--bg`, `--fg`, `--accent` etc.) with `prefers-color-scheme: dark` default + explicit toggle, persisted in localStorage.
- **CSS class reconciliation**: previous CSS styled `.btn-primary`, `.feature-card`, `.benchmark-table` etc. — none of which existed in the markup. New CSS targets the real class names; the page rendered with browser defaults before this fix.
- `prefers-reduced-motion` honoured. Skip-to-content link added. `:focus-visible` rings.
- **JS shrunk** from 418 → ~70 lines. Removed Chart.js, fake trend-data generator, `setTimeout(2000)` simulated loader, PerformanceObserver that just `console.log`'d. Kept theme toggle + copy buttons.
- **`deploy-pages.yml` rewritten**: previous workflow checked out an orphan `gh-pages` branch and `cp -r docs/* .` — which would now publish the Diataxis docs tree as the website root. New workflow stages `index.html` + `assets/` only.

## 3. Coverctl + nox grade badges

- **Codecov removed**. Replaced with `coverctl` self-hosted badge (`assets/badge-coverage.svg`), enforced via `coverctl check --fromProfile`. No third-party service dep.
- **Nox badge switched from "workflow status" to actual grade**. The `nox badge` CLI generates `assets/badge-nox.svg` from `findings.json` showing the security grade (currently F — honest; see Note below).
- Both badges committed to repo, served from `raw.githubusercontent.com`. Workflows refresh them on push to main and commit the diff (with `[skip ci]`).
- `.coverctl.yaml` cleaned up: removed stale `bolt/v3` paths and the genai entry (which broke `coverctl badge` because genai has its own go.mod).

## Note for maintainer (nox grade F)

Current grade is F because the baseline contains ~30 IAC-308 (workflow_dispatch enabled) notices on `mutation.yml` and similar low-severity items inflating the count. The nox `severity_override` mechanism in `.nox.yaml` can raise the grade by demoting these to "info" if intended — that's a policy decision before publishing the page widely.

## Test plan

- [x] `coverctl badge -p .cover/coverage.out -o assets/badge-coverage.svg` — 85.4% generated
- [x] `nox badge -output assets/badge-nox.svg` — grade F generated
- [x] Page renders correctly under both light + dark via media query
- [x] Theme toggle persists across reloads (localStorage)
- [x] Every copy button targets a real element ID
- [x] No Chart.js, no PerformanceObserver, no setTimeout theater in the new script.js
- [ ] Wait for CI: `coverctl check` will run and gate at 80% (current 85.4% — passes)