### PR TITLE
chore(genai): bump bolt dep to v1.4.0; prepare genai/v0.1.0 tag

### DIFF
--- a/genai/go.mod
+++ b/genai/go.mod
@@ -2,7 +2,7 @@ module github.com/felixgeelhaar/bolt/genai
 
 go 1.25.0
 
-require github.com/felixgeelhaar/bolt v1.3.0
+require github.com/felixgeelhaar/bolt v1.4.0
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/genai/go.sum
+++ b/genai/go.sum
@@ -26,3 +26,5 @@ golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=
 golang.org/x/term v0.43.0/go.mod h1:lrhlHNdQJHO+1qVYiHfFKVuVioJIheAc3fBSMFYEIsk=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+pgregory.net/rapid v1.3.0 h1:vBvO0VSqti75J1jjYqpgPNBLKMd1+gxa9fYo7vk/Exc=
+pgregory.net/rapid v1.3.0/go.mod h1:dPlE4OBBxgXPqkP79flB6sJL1dx5azpI7HQ9MY9Z7uk=


### PR DESCRIPTION
## Summary
- Bump `bolt/genai` sub-module dependency from `v1.3.0` → `v1.4.0`.
- Prerequisite for tagging `genai/v0.1.0` so pkg.go.dev resolves the sub-module.

## Why now
- Bolt core just shipped v1.4.0 with Hook v2 + EventHook (#59) — the surface that `genai.RedactHook` and `genai.AdaptiveSampler` are built on.
- Sub-module is currently untagged → `go get github.com/felixgeelhaar/bolt/genai` falls back to a pseudo-version + pkg.go.dev returns 404.

## Versioning rationale
- Starting at `v0.1.0` (not `v1.0.0`) because the OTel GenAI semantic conventions are still moving upstream. The genai/README explicitly calls this out:
  > "OTel GenAI semconv is still moving — keeping this package in its own go.mod lets it track semconv updates without dragging the bolt core through breaking releases."
- v0.x signals "API can change" while bolt core stays frozen at v1.x.

## After merge
1. Tag `genai/v0.1.0` at the merge commit
2. Push tag → release workflow runs (now with #76 fixes once that lands)
3. Warm proxy: `curl https://proxy.golang.org/github.com/felixgeelhaar/bolt/genai/@v/v0.1.0.info`
4. Trigger pkg.go.dev fetch

## Test plan
- [x] `cd genai && go test -short ./...` — passes locally
- [ ] CI green on this PR