### PR TITLE
fix(ci): use cosign v4 Sigstore bundle output for release signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,14 +114,13 @@ jobs:
         VERSION="${{ steps.version.outputs.version }}"
         ARCHIVE="${{ steps.archive.outputs.archive }}"
         SBOM="bolt_${VERSION}_sbom.spdx.json"
-        # Sign each file blob; produces .sig + .pem per blob.
+        # Sign each file blob; cosign v3+ emits a Sigstore bundle per blob.
         for blob in "$ARCHIVE" "$SBOM" checksums.txt; do
           cosign sign-blob --yes \
-            --output-signature "${blob}.sig" \
-            --output-certificate "${blob}.pem" \
+            --bundle "${blob}.sigstore.json" \
             "$blob"
         done
-        ls -lh *.sig *.pem
+        ls -lh *.sigstore.json
 
     - name: Compute base64 digest for SLSA provenance
       id: hashes
@@ -168,14 +167,11 @@ jobs:
           1.26 across Linux, macOS, and Windows.
         files: |
           ${{ steps.archive.outputs.archive }}
-          ${{ steps.archive.outputs.archive }}.sig
-          ${{ steps.archive.outputs.archive }}.pem
+          ${{ steps.archive.outputs.archive }}.sigstore.json
           bolt_${{ steps.version.outputs.version }}_sbom.spdx.json
-          bolt_${{ steps.version.outputs.version }}_sbom.spdx.json.sig
-          bolt_${{ steps.version.outputs.version }}_sbom.spdx.json.pem
+          bolt_${{ steps.version.outputs.version }}_sbom.spdx.json.sigstore.json
           checksums.txt
-          checksums.txt.sig
-          checksums.txt.pem
+          checksums.txt.sigstore.json
         draft: false
         prerelease: ${{ contains(github.ref, '-') }}
         generate_release_notes: true

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,18 +28,18 @@ the broader governance posture.
 Every release publishes:
 
 - `bolt_<version>_source.tar.gz` — deterministic source archive
-- `bolt_<version>_source.tar.gz.sig` + `.pem` — cosign keyless signature + cert
-- `bolt_<version>_sbom.spdx.json` — SPDX SBOM (and `.sig` / `.pem`)
-- `checksums.txt` — SHA-256 of the source archive (and `.sig` / `.pem`)
+- `bolt_<version>_source.tar.gz.sigstore.json` — cosign keyless Sigstore bundle
+- `bolt_<version>_sbom.spdx.json` — SPDX SBOM (and `.sigstore.json`)
+- `checksums.txt` — SHA-256 of the source archive (and `.sigstore.json`)
 - `bolt.intoto.jsonl` — SLSA-3 provenance attestation
 
 To verify a downloaded release:
 
 ```bash
-VERSION=v1.4.0   # adjust
+VERSION=v1.5.1   # adjust
 GH_REPO=klarlabs-studio/bolt
 
-# 1. Download the archive + signature + cert
+# 1. Download the archive + Sigstore bundle
 gh release download "$VERSION" --repo "$GH_REPO" \
   --pattern "bolt_${VERSION}_source.tar.gz*"
 
@@ -47,8 +47,7 @@ gh release download "$VERSION" --repo "$GH_REPO" \
 cosign verify-blob \
   --certificate-identity "https://github.com/${GH_REPO}/.github/workflows/release.yml@refs/tags/${VERSION}" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-  --certificate "bolt_${VERSION}_source.tar.gz.pem" \
-  --signature "bolt_${VERSION}_source.tar.gz.sig" \
+  --bundle "bolt_${VERSION}_source.tar.gz.sigstore.json" \
   "bolt_${VERSION}_source.tar.gz"
 
 # 3. Verify the SLSA-3 provenance attestation


### PR DESCRIPTION
cosign v3+ removed --output-signature/--output-certificate from
sign-blob; the release job failed with 'create bundle file: open :
no such file or directory'. Sign each blob into a .sigstore.json
bundle (same pattern as axi-go) and update release assets and
SECURITY.md verification commands accordingly.
