### PR TITLE
ci(lint): drop gosec — security owned by nox

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,7 +14,6 @@ linters:
   enable:
     - gocognit
     - gocyclo
-    - gosec
     - prealloc
     - revive
     - staticcheck
@@ -44,9 +43,6 @@ linters:
         - fmt.Fprintf
         - fmt.Fprintln
         - (*os.File).Close
-    gosec:
-      excludes:
-        - G115 # Disabled: upstream panic in gosec v2.23.0 conversion_overflow analyzer
     funlen:
       lines: 80
       statements: 50
@@ -84,14 +80,12 @@ linters:
           - errcheck
           - gocognit
           - gocyclo
-          - gosec
           - revive
           - unparam
           - unused
         path: _test\.go
       - linters:
           - errcheck
-          - gosec
           - gocognit
           - gocyclo
           - ineffassign
@@ -100,10 +94,6 @@ linters:
           - staticcheck
           - unparam
         path: examples/
-      - linters:
-          - gosec
-        path: bolt.go
-        text: G115.*integer overflow conversion.*int8
       - linters:
           - staticcheck
         path: bolt.go

--- a/bolt.go
+++ b/bolt.go
@@ -304,7 +304,7 @@ func (l *Logger) With() *Event {
 		levelValue = int64(INFO) // Default to INFO if somehow corrupted
 	}
 	// Safe conversion after bounds check
-	level := Level(levelValue) // #nosec G115 - bounds already checked above
+	level := Level(levelValue)
 	return &Event{buf: append([]byte{}, l.context...), level: level, l: l}
 }
 
@@ -331,7 +331,7 @@ func (l *Logger) log(level Level) *Event {
 		levelValue = int64(INFO) // Default to INFO if somehow corrupted
 	}
 	// Safe conversion after bounds check
-	currentLevel := Level(levelValue) // #nosec G115 - bounds already checked above
+	currentLevel := Level(levelValue)
 	if level < currentLevel {
 		return nil
 	}

--- a/examples/high-availability/load-balancer/main.go
+++ b/examples/high-availability/load-balancer/main.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math/rand" // #nosec G404 - Using weak random for examples is acceptable
+	"math/rand"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -460,7 +460,7 @@ func (app *Application) statsHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("X-Correlation-ID", correlationID)
 
-	_ = json.NewEncoder(w).Encode(map[string]interface{}{ // #nosec G104 - Example code
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
 		"load_balancer_stats": stats,
 		"timestamp":           time.Now().UTC().Format(time.RFC3339),
 		"correlation_id":      correlationID,
@@ -605,7 +605,6 @@ func runBackend(port int) {
 		Str("address", addr).
 		Msg("Starting backend server")
 
-	// #nosec G114 - Example code, timeout handling demonstrated elsewhere
 	if err := http.ListenAndServe(addr, mux); err != nil {
 		logger.Fatal().Err(err).Msg("Backend server failed")
 	}

--- a/examples/microservices/grpc-interceptors/main.go
+++ b/examples/microservices/grpc-interceptors/main.go
@@ -434,7 +434,6 @@ func runServer() error {
 	pb.RegisterUserServiceServer(server, userService)
 
 	// Listen on port
-	// #nosec G102 - Example code binding to all interfaces for demonstration
 	lis, err := net.Listen("tcp", ":9090")
 	if err != nil {
 		logger.Fatal().Err(err).Msg("Failed to listen on port 9090")

--- a/examples/observability/opentelemetry/main.go
+++ b/examples/observability/opentelemetry/main.go
@@ -8,7 +8,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"math/rand" // #nosec G404 - Using weak random for examples is acceptable
+	"math/rand"
 	"net/http"
 	"os"
 	"time"

--- a/examples/observability/prometheus/main.go
+++ b/examples/observability/prometheus/main.go
@@ -6,7 +6,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"math/rand" // #nosec G404 - Using weak random for examples is acceptable
+	"math/rand"
 	"net/http"
 	"os"
 	"strconv"

--- a/examples/security/pii-masking/main.go
+++ b/examples/security/pii-masking/main.go
@@ -436,7 +436,7 @@ func (app *Application) createUserHandler(w http.ResponseWriter, r *http.Request
 	maskedResponse := app.piiMasker.MaskStruct(user)
 
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(map[string]interface{}{ // #nosec G104 - Example code
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
 		"status":         "created",
 		"user":           maskedResponse,
 		"correlation_id": correlationID,

--- a/genai/genai.go
+++ b/genai/genai.go
@@ -54,7 +54,7 @@ const (
 
 	// Request fields
 	keyRequestModel       = "gen_ai.request.model"
-	keyRequestMaxTokens   = "gen_ai.request.max_tokens" // #nosec G101 -- OTel semconv field name, not a credential
+	keyRequestMaxTokens   = "gen_ai.request.max_tokens"
 	keyRequestTemperature = "gen_ai.request.temperature"
 	keyRequestTopP        = "gen_ai.request.top_p"
 
@@ -64,9 +64,9 @@ const (
 	keyResponseFinishReason = "gen_ai.response.finish_reasons"
 
 	// Usage fields
-	keyInputTokens  = "gen_ai.usage.input_tokens"  // #nosec G101 -- OTel semconv field name, not a credential
-	keyOutputTokens = "gen_ai.usage.output_tokens" // #nosec G101 -- OTel semconv field name, not a credential
-	keyTotalTokens  = "gen_ai.usage.total_tokens"  // #nosec G101 -- OTel semconv field name, not a credential
+	keyInputTokens  = "gen_ai.usage.input_tokens"
+	keyOutputTokens = "gen_ai.usage.output_tokens"
+	keyTotalTokens  = "gen_ai.usage.total_tokens"
 
 	// Timing
 	keyDuration = "gen_ai.client.operation.duration"


### PR DESCRIPTION
## Drop gosec — security is owned by nox

The org has standardized on **nox** for security scanning (secrets + IaC + dependency + AI + taint-analysis SAST), replacing gosec at the code-lint layer. The golden config in `klarlabs-studio/.github` (`golangci.reference.yml`) already dropped gosec; this PR brings `bolt` in line.

### Changes
- **`.golangci.yml`**: removed `gosec` from `linters.enable`, removed the `linters.settings.gosec` block (where present), and pruned gosec from `exclusions.rules` (dropping gosec-only rules entirely, removing the `gosec` token from mixed rules). Everything else — gocritic, the standard set, formatters, repo-specific config — is preserved unchanged.
- **Dead suppressions**: removed 13 now-unused gosec lint directives (`//nolint:gosec` / `// #nosec Gxxx`) that become dead once gosec is gone. For mixed `//nolint:errcheck,gosec` directives, only the `gosec` token was removed; the rest is kept.

### Verification
- `.golangci.yml` parses; no residual gosec references.
- `golangci-lint run ./...` (v2.12.2, the CI-pinned version) and `go build ./...` run locally.
- Removing gosec + its suppressions can only reduce lint findings.

No merge intended — opening for the Lint CI gate to confirm green.