### PR TITLE
ci(security): drop gosec — nox owns code-level security

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,7 +14,6 @@ linters:
   enable:
     - gocognit
     - gocyclo
-    - gosec
     - prealloc
     - revive
     - staticcheck
@@ -44,9 +43,6 @@ linters:
         - fmt.Fprintf
         - fmt.Fprintln
         - (*os.File).Close
-    gosec:
-      excludes:
-        - G115 # Disabled: upstream panic in gosec v2.23.0 conversion_overflow analyzer
     funlen:
       lines: 80
       statements: 50
@@ -84,14 +80,12 @@ linters:
           - errcheck
           - gocognit
           - gocyclo
-          - gosec
           - revive
           - unparam
           - unused
         path: _test\.go
       - linters:
           - errcheck
-          - gosec
           - gocognit
           - gocyclo
           - ineffassign
@@ -100,10 +94,6 @@ linters:
           - staticcheck
           - unparam
         path: examples/
-      - linters:
-          - gosec
-        path: bolt.go
-        text: G115.*integer overflow conversion.*int8
       - linters:
           - staticcheck
         path: bolt.go


### PR DESCRIPTION
nox/taint-analysis (cosign-verified, community trust, enforced in go-ci.yml) covers gosec's taint rules (G703/G704/G706); nox core covers credential/crypto/file-perm. Removes gosec from the linter set, settings and exclusion rules. `golangci-lint config verify` passes.