### PR TITLE
ci: drop cross-platform matrix (keep benchmark)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,10 @@
 # Thin caller for the shared klarlabs-studio Go CI bar.
 # All gate logic lives in the reusable workflow — bump versions / add jobs
-# there, once, org-wide. bolt is a perf-sensitive logging library, so it
-# opts into benchmark + cross-platform on top of the standard gate.
+# there, once, org-wide. bolt is a perf-sensitive logging library, so it keeps
+# the benchmark gate (push-to-main only). cross-platform is OFF: bolt's only
+# "OS-ish" code is ANSI color escapes (plain \x1b[..m strings, identical on
+# every OS) — no syscall/GOOS/console handling — so a macOS (10x billing) +
+# Windows matrix validated nothing.
 name: CI
 
 on:
@@ -25,6 +28,6 @@ jobs:
       pull-requests: write
     secrets: inherit
     with:
-      benchmark: true        # bolt cares about perf
-      cross-platform: true   # keep multi-OS on push-to-main
+      benchmark: true         # bolt's only benchmark coverage (push-to-main only)
+      cross-platform: false   # pure-Go + ANSI strings; nothing OS-specific to test
       coverage: true


### PR DESCRIPTION
Part of an org-wide CI-spend audit (fortify #53 is the sibling). bolt ran a 3-OS matrix (ubuntu + macOS + Windows) on every push to main; **macOS bills at 10×**.

## Verified: nothing OS-specific to test
bolt's only OS-touching code is **ANSI color escapes** — plain `\x1b[..m` strings written to the output writer (handler.go), identical on every OS. No `syscall`, no `runtime.GOOS`, no build tags, no `*_windows.go`, no Windows console-mode handling. The matrix validated nothing Go's runtime doesn't already guarantee.

## Change
`cross-platform: true` → `false`. **Keep `benchmark: true`** — bolt is a zero-alloc logger and this is its *only* benchmark coverage (no separate perf workflow), already push-to-main only.

## No coverage loss
PRs were **already ubuntu-only** (shared `go-ci.yml` gates the matrix to non-PR events) → PR feedback identical. Benchmarks + coverage gate unchanged.

Re-enable only if OS-specific source is ever added.

https://claude.ai/code/session_01KhcxqzoC2dgi2QibzBn3Sy