### PR TITLE
chore(ci): use reusable nox-remediate workflow

### DIFF
--- a/.github/workflows/nox-remediate.yml
+++ b/.github/workflows/nox-remediate.yml
@@ -1,8 +1,8 @@
+# Thin caller for the shared klarlabs-studio nox remediation.
+# Drop this in as .github/workflows/nox-remediate.yml. All logic lives in the
+# reusable workflow — bump the pinned nox version there, once, org-wide.
 name: Nox Remediate
 
-# Replaces dependabot: nox scans for OSV-vulnerable dependencies AND outdated
-# GitHub Actions pins, applies the fixes, and opens a single PR. The (org-wide)
-# auto-merge then merges it once CI is green.
 on:
   schedule:
     - cron: "17 6 * * 1" # Mondays 06:17 UTC
@@ -12,73 +12,9 @@ permissions:
   contents: write
   pull-requests: write
 
-concurrency:
-  group: nox-remediate-${{ github.ref }}
-  cancel-in-progress: true
-
-env:
-  NOX_VERSION: "1.4.0"
-  NOX_SHA256: "c244981f05724ad3167890fba6ee23909c5233e88c3813d4293145cb7e2ed1db"
-
 jobs:
   remediate:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 0
-          # The default GITHUB_TOKEN cannot push changes to .github/workflows/*
-          # (GitHub blocks it without the `workflows` scope), and remediating
-          # action pins edits workflow files. Provide a PAT with contents +
-          # pull-requests + workflows write as the NOX_TOKEN secret; falls back
-          # to GITHUB_TOKEN (fine for dependency-only remediation).
-          token: ${{ secrets.NOX_TOKEN || github.token }}
-          persist-credentials: true
-
-      # Toolchains for the dependency-tidy step (only used when a manifest is
-      # present). Go via the repo's go.mod; node fixed at 22.
-      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
-        with:
-          go-version: stable
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: "22"
-
-      - name: Install nox (pinned + sha256-verified)
-        run: |
-          url="https://github.com/nox-hq/nox/releases/download/v${NOX_VERSION}/nox_${NOX_VERSION}_linux_amd64.tar.gz"
-          curl -fsSL "$url" -o nox.tgz
-          echo "${NOX_SHA256}  nox.tgz" | sha256sum -c -
-          sudo tar xzf nox.tgz -C /usr/local/bin nox
-          rm nox.tgz
-
-      - name: Scan + remediate (dependencies + GitHub Actions pins)
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          nox scan . -format json -output . || true
-          # --actions bumps outdated action pins; the deps pass upgrades any
-          # OSV-vulnerable go/npm/pypi/cargo package with a fixed_in version.
-          nox fix --actions --input findings.json --root . || true
-          [ -f go.mod ] && go mod tidy || true
-
-      - name: Open remediation PR if anything changed
-        env:
-          GH_TOKEN: ${{ secrets.NOX_TOKEN || github.token }}
-        run: |
-          if git diff --quiet && git diff --cached --quiet; then
-            echo "nox: nothing to remediate."
-            exit 0
-          fi
-          branch="nox/remediate-${{ github.run_id }}"
-          git config user.name "nox-remediate"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git switch -c "$branch"
-          git commit -am "chore(security): nox remediation (deps + actions)"
-          git push -u origin "$branch"
-          url="$(gh pr create \
-            --title "chore(security): nox remediation" \
-            --body "Automated remediation by \`nox fix --actions\`: OSV-vulnerable dependency upgrades and outdated GitHub Actions pins bumped to their latest SHA-pinned release. Replaces dependabot." \
-            --label dependencies)"
-          # Auto-merge once CI is green (same flow dependabot PRs used).
-          gh pr merge --auto --squash "$url" || true
+    uses: klarlabs-studio/.github/.github/workflows/nox-remediate.yml@main
+    secrets: inherit
+    # with:
+    #   include-major: true   # also apply major-version action bumps


### PR DESCRIPTION
Replaces this repo's copy of `nox-remediate.yml` with a thin caller of the shared reusable workflow `klarlabs-studio/.github/.github/workflows/nox-remediate.yml@main` (now pinning nox 1.4.1, which SHA-pins mutable action tags). Future nox bumps happen once, org-wide, instead of in every repo.

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom