### PR TITLE
fix(ci): run CI on docs-only PRs so required checks can report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,12 @@ on:
     paths-ignore: ["**.md", "docs/**", "LICENSE"]
   pull_request:
     branches: [main]
-    paths-ignore: ["**.md", "docs/**", "LICENSE"]
+    # No paths-ignore here: branch protection requires this workflow's status
+    # checks (ci / Lint, Test, Build, Security (nox)), and a docs-only PR that
+    # skips the whole workflow never reports them — so the PR is unmergeable
+    # forever without an admin override. Running CI on docs PRs is cheap (no
+    # code changed → cache hits) and keeps them mergeable; the push trigger
+    # above still skips docs, saving minutes on merges.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Problem
Branch protection on `main` requires `ci / Lint`, `ci / Test (ubuntu-latest)`, `ci / Build`, `ci / Security (nox)` — but `ci.yml` had `paths-ignore` on the **`pull_request`** trigger. A docs-only PR skips the workflow entirely → required checks never report → the PR is `BLOCKED` forever, landable only with an admin override.

## Fix
Drop `paths-ignore` from the `pull_request` trigger. The `push`-to-`main` trigger **keeps** it, so merging docs changes still skips CI. Running CI on a docs PR is cheap (no code changed → cache hits).

Completes the fleet-wide sweep — bolt was the last affected repo (already fixed: warden, nox, statekit, agent-go, auth-go, axi-go, briefkasten, coverctl, fortify, mcp-go, scout).

https://claude.ai/code/session_01Cr6YdzphmFF3NJqm7kSJom