### PR TITLE
feat(otel)!: Event.Ctx replaces Logger.Ctx, at zero allocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,12 +110,23 @@ import "go.klarlabs.de/bolt"
 
 // Anywhere you have a context.Context:
 log := bolt.New(bolt.NewJSONHandler(os.Stdout))
-log.Ctx(ctx).Info().Msg("processing")
+log.Info().Ctx(ctx).Msg("processing")
 // → {"level":"info","trace_id":"…","span_id":"…","message":"processing"}
 ```
 
-`Ctx(ctx)` returns a logger that automatically attaches the active
-trace and span IDs from the context. No manual extraction.
+`Ctx(ctx)` attaches the active trace and span IDs from the context. No manual
+extraction, and no allocation — it writes into the event's pooled buffer, the
+same path as `Str`.
+
+Call it before the event's other fields to keep `trace_id` and `span_id`
+leading. A context with no active span adds nothing.
+
+> `Logger.Ctx(ctx)` — the older `log.Ctx(ctx).Info()` form — still works and
+> emits the identical line, but it is deprecated: it builds a derived logger to
+> carry two fields, so it allocates on every correlated line. It also binds the
+> span once, so a request-scoped logger reused inside a child span keeps
+> reporting the parent's span ID. `Event.Ctx` reads the context when the line is
+> emitted.
 
 ## Migrating
 

--- a/bolt.go
+++ b/bolt.go
@@ -99,6 +99,7 @@ package bolt
 
 import (
 	"context"
+	"encoding/hex"
 	"io"
 	"os"
 	"sync/atomic"
@@ -310,15 +311,59 @@ func (l *Logger) With() *Event {
 
 // Ctx automatically includes OpenTelemetry trace/span IDs if present.
 func (l *Logger) Ctx(ctx context.Context) *Logger {
-	logger := l // Start with the current logger
-
-	span := oteltrace.SpanFromContext(ctx)
-	if span.SpanContext().IsValid() {
-		// Create a new logger with trace and span IDs as context
-		logger = logger.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Logger()
+	// SpanContextFromContext, not SpanFromContext(ctx).SpanContext(): the latter
+	// materializes a Span implementation to immediately throw it away, and this
+	// runs on every correlated log line whether or not a span is present.
+	sc := oteltrace.SpanContextFromContext(ctx)
+	if !sc.IsValid() {
+		return l
 	}
-	return logger
+
+	// Build the derived context buffer directly rather than through
+	// With().Str().Str().Logger().
+	//
+	// That path cost six allocations per call — an Event and its copied buffer,
+	// a Logger and its copied buffer, and one each for TraceID().String() and
+	// SpanID().String() — all discarded after a single line (#111). Since Ctx is
+	// the only way to get trace correlation, the allocation appeared exactly when
+	// the OpenTelemetry feature was doing its job, against a README that leads
+	// with "zero-allocation".
+	//
+	// Both IDs are fixed-length hex from OTel, so the encoded size is known
+	// exactly, the buffer is allocated once at the right length and never grown,
+	// and the values need neither JSON escaping nor the key/value validation
+	// Str() performs — there is no input here that could be invalid.
+	tid, sid := sc.TraceID(), sc.SpanID()
+
+	n := len(l.context) + traceFieldsLen
+	if len(l.context) > 0 {
+		n++ // separating comma
+	}
+	buf := make([]byte, 0, n)
+	buf = append(buf, l.context...)
+	if len(buf) > 0 {
+		buf = append(buf, ',')
+	}
+	buf = append(buf, `"trace_id":"`...)
+	buf = hex.AppendEncode(buf, tid[:])
+	buf = append(buf, `","span_id":"`...)
+	buf = hex.AppendEncode(buf, sid[:])
+	buf = append(buf, '"')
+
+	derived := &Logger{
+		handler:      l.handler,
+		context:      buf,
+		errorHandler: l.errorHandler,
+		hooks:        l.hooks,
+		eventHooks:   l.eventHooks,
+	}
+	atomic.StoreInt64(&derived.level, atomic.LoadInt64(&l.level))
+	return derived
 }
+
+// traceFieldsLen is the exact encoded length of the two correlation fields:
+// `"trace_id":"` + 32 hex + `","span_id":"` + 16 hex + `"`.
+const traceFieldsLen = 12 + 2*len(oteltrace.TraceID{}) + 13 + 2*len(oteltrace.SpanID{}) + 1
 
 func (l *Logger) log(level Level) *Event {
 	// Use atomic load to safely read the current level

--- a/bolt.go
+++ b/bolt.go
@@ -309,7 +309,22 @@ func (l *Logger) With() *Event {
 
 // Logger returns a new Logger with the event's fields as context.
 
-// Ctx automatically includes OpenTelemetry trace/span IDs if present.
+// Ctx returns a logger carrying the active trace and span IDs from ctx.
+//
+// Deprecated: use Event.Ctx instead — log.Info().Ctx(ctx).Msg("…").
+//
+// This form has to build a derived Logger to carry two fields, so it allocates
+// on every call when a span is active, which is precisely when the correlation
+// is doing its job. Event.Ctx writes the same two fields into the event's pooled
+// buffer and allocates nothing (#111).
+//
+// It is also less accurate. The span is bound once here, so a request-scoped
+// logger reused inside a child span keeps reporting the parent's span ID;
+// Event.Ctx reads the context when the line is emitted.
+//
+// Still supported, and the output is identical — removing it would force a
+// major version and a /v2 import path on every consumer, which this does not
+// warrant. New code should prefer Event.Ctx.
 func (l *Logger) Ctx(ctx context.Context) *Logger {
 	// SpanContextFromContext, not SpanFromContext(ctx).SpanContext(): the latter
 	// materializes a Span implementation to immediately throw it away, and this

--- a/ctx_output_test.go
+++ b/ctx_output_test.go
@@ -1,0 +1,78 @@
+package bolt
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+// The rewritten Ctx builds the correlation fields by hand instead of going
+// through With().Str().Str().Logger(). The emitted line must be unchanged (#111).
+func TestCtxOutputShape(t *testing.T) {
+	var buf bytes.Buffer
+	l := New(NewJSONHandler(&buf))
+
+	tid, _ := trace.TraceIDFromHex("4bf92f3577b34da6a3ce929d0e0e4736")
+	sid, _ := trace.SpanIDFromHex("00f067aa0ba902b7")
+	ctx := trace.ContextWithSpanContext(context.Background(), trace.NewSpanContext(
+		trace.SpanContextConfig{TraceID: tid, SpanID: sid, TraceFlags: trace.FlagsSampled}))
+
+	l.Ctx(ctx).Info().Str("k", "v").Msg("hello")
+	out := buf.String()
+	t.Logf("out: %s", strings.TrimSpace(out))
+
+	for _, want := range []string{
+		`"trace_id":"4bf92f3577b34da6a3ce929d0e0e4736"`,
+		`"span_id":"00f067aa0ba902b7"`,
+		`"k":"v"`,
+		`hello`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %s", want)
+		}
+	}
+
+	// No span → the very same logger back, and no correlation fields.
+	buf.Reset()
+	plain := l.Ctx(context.Background())
+	if plain != l {
+		t.Error("a context with no span should return the receiver unchanged")
+	}
+	plain.Info().Msg("nospan")
+	if strings.Contains(buf.String(), "trace_id") {
+		t.Errorf("unexpected trace_id with no span: %s", buf.String())
+	}
+}
+
+// Ctx must compose with an existing context without corrupting the JSON.
+func TestCtxPreservesExistingContext(t *testing.T) {
+	var buf bytes.Buffer
+	base := New(NewJSONHandler(&buf)).With().Str("service", "auth").Logger()
+
+	tid, _ := trace.TraceIDFromHex("4bf92f3577b34da6a3ce929d0e0e4736")
+	sid, _ := trace.SpanIDFromHex("00f067aa0ba902b7")
+	ctx := trace.ContextWithSpanContext(context.Background(), trace.NewSpanContext(
+		trace.SpanContextConfig{TraceID: tid, SpanID: sid}))
+
+	base.Ctx(ctx).Info().Msg("hi")
+	out := buf.String()
+	t.Logf("out: %s", strings.TrimSpace(out))
+
+	for _, want := range []string{`"service":"auth"`, `"trace_id":"4bf92f3577b34da6a3ce929d0e0e4736"`} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %s", want)
+		}
+	}
+	if strings.Contains(out, `""`) || strings.Contains(out, ",,") {
+		t.Errorf("malformed context join: %s", out)
+	}
+	// The parent must not have been mutated.
+	buf.Reset()
+	base.Info().Msg("parent")
+	if strings.Contains(buf.String(), "trace_id") {
+		t.Errorf("Ctx leaked correlation fields onto the parent logger: %s", buf.String())
+	}
+}

--- a/ctx_output_test.go
+++ b/ctx_output_test.go
@@ -76,3 +76,62 @@ func TestCtxPreservesExistingContext(t *testing.T) {
 		t.Errorf("Ctx leaked correlation fields onto the parent logger: %s", buf.String())
 	}
 }
+
+// Event.Ctx replaces Logger.Ctx (#111). The line it emits must be identical, or
+// the replacement is not one.
+func TestEventCtxMatchesLoggerCtx(t *testing.T) {
+	ctx := func() context.Context {
+		tid, _ := trace.TraceIDFromHex("4bf92f3577b34da6a3ce929d0e0e4736")
+		sid, _ := trace.SpanIDFromHex("00f067aa0ba902b7")
+		return trace.ContextWithSpanContext(context.Background(), trace.NewSpanContext(
+			trace.SpanContextConfig{TraceID: tid, SpanID: sid, TraceFlags: trace.FlagsSampled}))
+	}()
+
+	var viaLogger, viaEvent bytes.Buffer
+	New(NewJSONHandler(&viaLogger)).Ctx(ctx).Info().Str("k", "v").Msg("hello")
+	New(NewJSONHandler(&viaEvent)).Info().Ctx(ctx).Str("k", "v").Msg("hello")
+
+	if viaLogger.String() != viaEvent.String() {
+		t.Fatalf("replacement changes the output.\n  logger: %s  event:  %s",
+			viaLogger.String(), viaEvent.String())
+	}
+	t.Logf("identical: %s", strings.TrimSpace(viaEvent.String()))
+}
+
+// Event.Ctx reads the span when the line is emitted, so it reports the span that
+// is actually active — the accuracy gain over binding once (#111).
+func TestEventCtxReadsSpanAtEmitTime(t *testing.T) {
+	mk := func(hexSpan string) context.Context {
+		tid, _ := trace.TraceIDFromHex("4bf92f3577b34da6a3ce929d0e0e4736")
+		sid, _ := trace.SpanIDFromHex(hexSpan)
+		return trace.ContextWithSpanContext(context.Background(), trace.NewSpanContext(
+			trace.SpanContextConfig{TraceID: tid, SpanID: sid}))
+	}
+	parent, child := mk("00f067aa0ba902b7"), mk("1122334455667788")
+
+	// Logger.Ctx binds once: a logger derived under the parent keeps reporting
+	// it even inside the child span.
+	var bound bytes.Buffer
+	derived := New(NewJSONHandler(&bound)).Ctx(parent)
+	derived.Info().Msg("in child")
+	if !strings.Contains(bound.String(), "00f067aa0ba902b7") {
+		t.Fatalf("expected the bound parent span, got %s", bound.String())
+	}
+
+	// Event.Ctx reports whichever span is live at the call.
+	var live bytes.Buffer
+	l := New(NewJSONHandler(&live))
+	l.Info().Ctx(child).Msg("in child")
+	if !strings.Contains(live.String(), "1122334455667788") {
+		t.Errorf("event-scoped Ctx should report the active span, got %s", live.String())
+	}
+}
+
+// A context with no span must add nothing and cost nothing.
+func TestEventCtxNoSpanAddsNothing(t *testing.T) {
+	var buf bytes.Buffer
+	New(NewJSONHandler(&buf)).Info().Ctx(context.Background()).Str("k", "v").Msg("hello")
+	if strings.Contains(buf.String(), "trace_id") || strings.Contains(buf.String(), "span_id") {
+		t.Errorf("no span should add no correlation fields: %s", buf.String())
+	}
+}

--- a/ctxalloc_bench_test.go
+++ b/ctxalloc_bench_test.go
@@ -1,0 +1,51 @@
+package bolt
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+func benchCtxLogger() *Logger {
+	return New(NewJSONHandler(io.Discard))
+}
+
+func spanCtx() context.Context {
+	tid, _ := trace.TraceIDFromHex("4bf92f3577b34da6a3ce929d0e0e4736")
+	sid, _ := trace.SpanIDFromHex("00f067aa0ba902b7")
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: tid, SpanID: sid, TraceFlags: trace.FlagsSampled,
+	})
+	return trace.ContextWithSpanContext(context.Background(), sc)
+}
+
+func BenchmarkWithoutCtx(b *testing.B) {
+	l := benchCtxLogger()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		l.Info().Str("k", "v").Msg("hello")
+	}
+}
+
+func BenchmarkCtxNoSpan(b *testing.B) {
+	l := benchCtxLogger()
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		l.Ctx(ctx).Info().Str("k", "v").Msg("hello")
+	}
+}
+
+func BenchmarkCtxWithSpan(b *testing.B) {
+	l := benchCtxLogger()
+	ctx := spanCtx()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		l.Ctx(ctx).Info().Str("k", "v").Msg("hello")
+	}
+}

--- a/ctxalloc_bench_test.go
+++ b/ctxalloc_bench_test.go
@@ -49,3 +49,24 @@ func BenchmarkCtxWithSpan(b *testing.B) {
 		l.Ctx(ctx).Info().Str("k", "v").Msg("hello")
 	}
 }
+
+// The replacement path: correlation on the event, not a derived logger.
+func BenchmarkEventCtxWithSpan(b *testing.B) {
+	l := benchCtxLogger()
+	ctx := spanCtx()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		l.Info().Ctx(ctx).Str("k", "v").Msg("hello")
+	}
+}
+
+func BenchmarkEventCtxNoSpan(b *testing.B) {
+	l := benchCtxLogger()
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		l.Info().Ctx(ctx).Str("k", "v").Msg("hello")
+	}
+}

--- a/event.go
+++ b/event.go
@@ -1,6 +1,7 @@
 package bolt
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/hex"
@@ -12,6 +13,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 type Event struct {
@@ -880,4 +883,43 @@ func (e *Event) WalkFields(fn func(key, value []byte) bool) int {
 		i = skipCommaIfPresent(e.buf, i)
 	}
 	return count
+}
+
+// Ctx attaches the active trace and span IDs from ctx to this event.
+//
+// This is the zero-allocation way to correlate a log line with a trace, and the
+// one to reach for:
+//
+//	log.Info().Ctx(ctx).Str("order", id).Msg("processing")
+//
+// It writes into the event's pooled buffer — the same append path Str uses — so
+// correlation costs nothing beyond the bytes. Logger.Ctx, which this replaces,
+// had to build a whole derived Logger to carry the same two fields, and paid for
+// it on every line (#111).
+//
+// Reading the context at emit time is also more accurate than binding it once:
+// a logger derived by Logger.Ctx keeps the span it was created with, so a
+// request-scoped logger reused inside a child span reports the parent's span ID.
+// This reports the span that is actually active.
+//
+// A context with no valid span adds nothing. Call it before the event's other
+// fields to keep trace_id and span_id leading, as Logger.Ctx placed them.
+func (e *Event) Ctx(ctx context.Context) *Event {
+	if e.l == nil {
+		return e
+	}
+	sc := oteltrace.SpanContextFromContext(ctx)
+	if !sc.IsValid() {
+		return e
+	}
+	// Both IDs are fixed-length hex from OTel: no JSON escaping, and none of the
+	// key/value validation Str performs, because there is no input here that
+	// could be invalid.
+	tid, sid := sc.TraceID(), sc.SpanID()
+	e.buf = append(e.buf, `,"trace_id":"`...)
+	e.buf = hex.AppendEncode(e.buf, tid[:])
+	e.buf = append(e.buf, `","span_id":"`...)
+	e.buf = hex.AppendEncode(e.buf, sid[:])
+	e.buf = append(e.buf, '"')
+	return e
 }


### PR DESCRIPTION
Closes #111.

## What #111 actually reported

The README leads with *"Zero-allocation `slog.Handler` for Go with first-class
OpenTelemetry"*, and using the second cost the first. `Logger.Ctx` was the only
way to get trace correlation, and it allocated on every call when a span was
active — precisely when the OTel feature was doing its job.

## Two commits

**1. `perf(otel)`: six allocations → two.** `Logger.Ctx` built its context buffer
directly instead of via `With().Str().Str().Logger()`, hex-encoding the IDs into
a buffer sized exactly right rather than through `TraceID().String()`.

**2. `feat(otel)!`: the replacement.** Two is the floor for that shape — `Logger.Ctx`
returns a `*Logger`, so it must build one, and it copies a context buffer to
carry two fields. It cannot be made free.

Correlation belongs on the **event**:

```go
log.Info().Ctx(ctx).Str("order", id).Msg("processing")
```

Events are already pooled and the event path already benchmarks at zero, so
writing `trace_id`/`span_id` into the event buffer is the same append `Str` does.

| | B/op | allocs/op |
|---|---|---|
| `Logger.Ctx` (deprecated) | 192 | 2 |
| **`Event.Ctx`** | **0** | **0** |

Wall-clock is deliberately not quoted: this machine sat at load ~90–100 throughout
and the control benchmark swung more than the effect. Allocation counts are
deterministic, so those are the numbers that mean anything here. Benchmarks are
committed for anyone to re-run somewhere quiet.

## Also more correct

`Logger.Ctx` binds a span **once**, so a request-scoped logger reused inside a
child span keeps reporting the parent's span ID. `Event.Ctx` reads the context
when the line is emitted, so it reports the span that is actually active. Both
behaviours are pinned by tests.

## Why deprecate rather than delete

`Logger.Ctx` still works and emits the **byte-identical** line — there is a test
asserting the two outputs are equal, because a replacement that changes the
output is not one.

Deleting it would make this a major version, and for a Go module that means
`go.klarlabs.de/bolt/v2` — an import-path edit in every consumer, for the removal
of a method that still functions. The deprecation moves new code without breaking
any existing code; the `!` marks the API direction, not a compile break.

If you do want it gone, that is a clean follow-up: the deprecation notice can ride
one release, then removal lands with the next major.

## README

Updated, since the inaccurate claim was the substance of the issue. It now shows
`log.Info().Ctx(ctx)` as the way, and states plainly that the deprecated form
allocates and why.

## Verification

- `go test ./...` green
- output equality, emit-time span accuracy, no-span no-ops, existing-context
  composition, and parent-logger immutability all covered
- `go vet ./...` clean