### PR TITLE
ci(warden): let lint run alongside another repository's lint

### DIFF
--- a/.warden.yaml
+++ b/.warden.yaml
@@ -2,7 +2,7 @@
 # Any dev with warden installed gets the same checks CI runs, pre-commit/pre-push.
 hooks: { pre_commit: true, pre_push: true }
 commands:
-  lint: "golangci-lint run ./..."
+  lint: "golangci-lint run --allow-parallel-runners ./..."
   test: "go test -race ./..."
 steps:
   pre_commit: [lint]


### PR DESCRIPTION
`golangci-lint` locks the **shared** cache, so a lint running in any *other* repository on the machine blocks this repo's gate for a minute and it exits 75.

That used to be theoretical. With several agent sessions working the fleet concurrently it is constant — it cost multiple re-runs in a single afternoon, and every one of them looks like a failure until you read the message.

warden already isolates each run's `GOLANGCI_LINT_CACHE`, which is exactly what that lock protects, so the flag golangci-lint's own error message recommends is safe here.

16 of 26 repos in this fleet had the same exposure; this is one of them.

https://claude.ai/code/session_01N9cWx4ZEypDzzhvnnTiHdy