### PR TITLE
fix(security): build with a patched Go toolchain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module go.klarlabs.de/bolt
 
 go 1.25.0
 
+toolchain go1.25.14
+
 require (
 	go.opentelemetry.io/otel/trace v1.44.0
 	pgregory.net/rapid v1.3.0


### PR DESCRIPTION
Part of a fleet-wide sweep: **40 of 43 Go repositories** build on a Go toolchain behind on security patches.

## Why

`setup-go` resolves the toolchain from `go.mod` and reads the `go` directive as an **exact version**, not a floor. So every build here used that exact patch release, and govulncheck reports reachable call paths from this module into its standard library.

The findings were invisible because the failing step's log is not retrievable — they appear only in the check run's annotations.

## The change

```
toolchain go1.25.14
```

The `go` directive is untouched, so nothing importing this module has its floor raised, and the Go command honours the toolchain everywhere — CI, releases, and a developer's laptop.

## Verification

Built and scanned with the resolution CI performs. `govulncheck` exits 0.

Analysis and the fleet survey: klarlabs-studio/.github#73. Already merged: klarlabs-studio/kiln#48, klarlabs-studio/warden#242.

https://claude.ai/code/session_01N9cWx4ZEypDzzhvnnTiHdy